### PR TITLE
Add PNG export (issue #11)

### DIFF
--- a/my-app/src/test/konva-stub.ts
+++ b/my-app/src/test/konva-stub.ts
@@ -1,8 +1,14 @@
 import { vi } from 'vitest'
 
 /** Shared Konva Stage stub — imported by setup.ts mock factory and test files. */
+const mockBlob = new Blob([''], { type: 'image/png' })
+
+export const mockCanvas = {
+  toBlob: vi.fn((cb: (b: Blob | null) => void) => cb(mockBlob)),
+}
+
 export const stageStub = {
   getPointerPosition: () => ({ x: 0, y: 0 }),
   container: () => document.createElement('div'),
-  toDataURL: vi.fn(() => 'data:image/png;base64,mock'),
+  toCanvas: vi.fn(() => mockCanvas),
 }

--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TrafficControlPlanner from '../traffic-control-planner'
-import { stageStub } from './konva-stub'
+import { stageStub, mockCanvas } from './konva-stub'
 
 beforeEach(() => {
   localStorage.clear()
@@ -228,8 +228,12 @@ describe('PNG export', () => {
     await expect(user.click(screen.getByTestId('export-png-button'))).resolves.not.toThrow()
   })
 
-  it('triggers a PNG download with pixelRatio 2 and a .png filename', async () => {
-    stageStub.toDataURL.mockClear()
+  it('triggers a PNG download via Blob with pixelRatio 2 and revokes the URL', async () => {
+    stageStub.toCanvas.mockClear()
+    mockCanvas.toBlob.mockClear()
+    ;(URL.createObjectURL as ReturnType<typeof vi.fn>).mockClear()
+    ;(URL.revokeObjectURL as ReturnType<typeof vi.fn>).mockClear()
+
     const mockAnchor = { href: '', download: '', click: vi.fn() }
     const realCreateElement = document.createElement.bind(document)
     const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) =>
@@ -239,10 +243,12 @@ describe('PNG export', () => {
     const { user } = setup()
     await user.click(screen.getByTestId('export-png-button'))
 
-    expect(stageStub.toDataURL).toHaveBeenCalledWith({ pixelRatio: 2 })
-    expect(mockAnchor.href).toBe('data:image/png;base64,mock')
+    expect(stageStub.toCanvas).toHaveBeenCalledWith({ pixelRatio: 2 })
+    expect(mockCanvas.toBlob).toHaveBeenCalledWith(expect.any(Function), 'image/png')
+    expect(mockAnchor.href).toBe('blob:mock-url')
     expect(mockAnchor.download).toMatch(/\.png$/)
     expect(mockAnchor.click).toHaveBeenCalled()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
 
     createElementSpy.mockRestore()
   })

--- a/my-app/src/test/setup.ts
+++ b/my-app/src/test/setup.ts
@@ -90,3 +90,7 @@ Object.defineProperty(globalThis, 'localStorage', {
 })
 
 globalThis.prompt = vi.fn().mockReturnValue(null)
+
+// URL object stubs (jsdom doesn't implement createObjectURL/revokeObjectURL)
+globalThis.URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+globalThis.URL.revokeObjectURL = vi.fn()

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -1749,8 +1749,13 @@ export default function TrafficControlPlanner() {
   const exportPNG = () => {
     const stage = stageRef.current;
     if (!stage) return;
-    const dataURL = stage.toDataURL({ pixelRatio: 2 });
-    triggerDownload(dataURL, `${safePlanTitle}.png`);
+    const canvas = stage.toCanvas({ pixelRatio: 2 });
+    canvas.toBlob((blob: Blob | null) => {
+      if (!blob) return;
+      const url = URL.createObjectURL(blob);
+      triggerDownload(url, `${safePlanTitle}.png`);
+      URL.revokeObjectURL(url);
+    }, "image/png");
   };
 
   const loadPlan = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- Adds `exportPNG()` using Konva's `stage.toDataURL({ pixelRatio: 2 })` for a high-resolution 2× export
- Triggers a browser download as `<plan-name>.png`
- "↓ PNG" button added to the toolbar next to Save
- Closes #11

## Test plan
- [x] `npm run test` — all 60 tests pass (2 new PNG export tests)
- [x] `npm run build` — zero TypeScript errors
- [x] Export PNG button visible in toolbar
- [x] Clicking it does not throw (mocked stage returns a data URL)
- [x] Stage mock updated with `toDataURL` stub so existing tests aren't affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add PNG export capability from the planner canvas and expose it via the toolbar.

New Features:
- Enable exporting the Konva stage as a high-resolution PNG file named after the current plan.
- Add a PNG export button to the planner toolbar alongside the existing Save control.

Tests:
- Add tests to verify the PNG export button appears in the toolbar and can be clicked without errors when no stage is available.
- Extend the React Konva stage test mock with a toDataURL stub to support PNG export tests.