### PR TITLE
Add north arrow overlay (issue #12)

### DIFF
--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -88,9 +88,11 @@ describe('Plan metadata', () => {
 
 // ─── North arrow ──────────────────────────────────────────────────────────────
 describe('North arrow', () => {
-  it('is visible by default', () => {
+  it('is visible by default and does not block canvas interactions', () => {
     setup()
-    expect(screen.getByTestId('north-arrow')).toBeInTheDocument()
+    const el = screen.getByTestId('north-arrow')
+    expect(el).toBeInTheDocument()
+    expect(el).toHaveStyle({ pointerEvents: 'none' })
   })
 
   it('toggle checkbox hides the north arrow', async () => {

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -17,7 +17,8 @@ import { uid, dist, angleBetween, geoRoadWidthPx, snapToEndpoint, sampleBezier, 
 const GRID_SIZE = 20;
 const MIN_ZOOM = 0.1;
 const MAX_ZOOM = 5;
-const SNAP_RADIUS = 14; // screen-pixels for endpoint snap
+const SNAP_RADIUS = 14;    // screen-pixels for endpoint snap
+const STATUS_BAR_H = 28;   // height of the bottom status bar in px
 
 const COLORS = {
   bg: "#0f1117",
@@ -877,19 +878,35 @@ function SignEditorPanel({ onUseSign, onSaveToLibrary }: SignEditorPanelProps) {
 
 // ─── NORTH ARROW ─────────────────────────────────────────────────────────────
 
+const northArrowStyle: React.CSSProperties = {
+  position: "absolute",
+  bottom: STATUS_BAR_H + 8,
+  right: 12,
+  width: 44,
+  height: 44,
+  borderRadius: "50%",
+  background: "rgba(26,29,39,0.88)",
+  border: `1px solid ${COLORS.panelBorder}`,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  pointerEvents: "none",
+  zIndex: 10,
+};
+
 function NorthArrow({ visible }: { visible: boolean }) {
   if (!visible) return null;
   return (
-    <div data-testid="north-arrow" style={{ position: "absolute", bottom: 36, right: 12, width: 44, height: 44, borderRadius: "50%", background: "rgba(26,29,39,0.88)", border: `1px solid ${COLORS.panelBorder}`, display: "flex", alignItems: "center", justifyContent: "center", pointerEvents: "none", zIndex: 10 }}>
+    <div data-testid="north-arrow" style={northArrowStyle}>
       <svg width="36" height="36" viewBox="0 0 36 36" aria-label="North arrow">
-        {/* North needle (red) */}
-        <polygon points="18,5 15,19 21,19" fill="#ef4444" />
+        {/* North needle */}
+        <polygon points="18,5 15,19 21,19" fill={COLORS.danger} />
         {/* South needle (muted) */}
         <polygon points="18,31 15,19 21,19" fill={COLORS.textDim} />
         {/* Centre pivot */}
         <circle cx="18" cy="19" r="2.5" fill={COLORS.text} />
         {/* N label */}
-        <text x="18" y="4" textAnchor="middle" dominantBaseline="auto" fontSize="7" fontWeight="bold" fill="#ef4444" fontFamily="'JetBrains Mono',monospace">N</text>
+        <text x="18" y="4" textAnchor="middle" dominantBaseline="auto" fontSize="7" fontWeight="bold" fill={COLORS.danger} fontFamily="'JetBrains Mono',monospace">N</text>
       </svg>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a `NorthArrow` component — a fixed screen-space SVG compass rendered as an absolute overlay on the canvas container
- Red needle = North, muted needle = South, with "N" label and white centre pivot
- Positioned bottom-right (above the status bar) so it survives pan/zoom without moving
- Defaults to **visible** (required on all TCP submittals) with a "North Arrow" toggle checkbox in the Canvas section of the left panel
- Closes #12

## Test plan
- [x] `npm run test` — all 78 tests pass (3 new)
- [x] `npm run build` — zero TypeScript errors
- [x] North arrow visible on load by default
- [x] Toggle checkbox hides/shows the arrow
- [x] Arrow stays fixed during pan and zoom (screen-space, not world-space)
- [x] `pointer-events: none` so it doesn't interfere with canvas interactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a screen-space north arrow overlay to the traffic control planner canvas with a user-toggleable control.

New Features:
- Introduce a NorthArrow overlay component rendered as a fixed SVG compass on the canvas container.
- Add a "North Arrow" checkbox in the canvas controls panel to toggle the overlay visibility.

Tests:
- Add integration tests verifying the north arrow is visible by default and can be hidden and re-shown via the toggle control.