### PR TITLE
Add password-protected feedback portal and Report Issue button

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,15 @@
+import json
 import logging
 import os
+import urllib.error
+import urllib.request
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 from mangum import Mangum
 
-from models import ExportRequest
+from models import CreateIssueRequest, ExportRequest
 from pdf_generator import build_pdf
 
 logger = logging.getLogger(__name__)
@@ -48,6 +51,64 @@ def export_pdf(payload: ExportRequest) -> Response:
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+_LABEL_MAP = {
+    "bug":         ["bug", "backlog"],
+    "feature":     ["enhancement", "feature request", "backlog"],
+    "enhancement": ["enhancement", "backlog"],
+    "question":    ["question", "backlog"],
+}
+
+_PRIORITY_EMOJI = {"low": "🟢", "medium": "🟡", "high": "🟠", "critical": "🔴"}
+
+
+@app.post("/create-issue")
+def create_issue(payload: CreateIssueRequest):
+    token = os.getenv("GITHUB_TOKEN", "")
+    repo = os.getenv("GITHUB_REPO", "jfisher94002/TrafficControlPlanner")
+
+    if not token:
+        raise HTTPException(status_code=503, detail="Issue creation is not configured on this server.")
+
+    priority_label = f"{_PRIORITY_EMOJI[payload.priority]} {payload.priority.capitalize()}"
+    issue_body = (
+        f"## {payload.issue_type.capitalize()} Report\n\n"
+        f"**Submitted by:** {payload.submitter_name}\n"
+        f"**Priority:** {priority_label}\n"
+        f"**Type:** {payload.issue_type}\n\n"
+        f"---\n\n"
+        f"{payload.body}\n\n"
+        f"---\n*Submitted via TCP Feedback Portal*"
+    )
+
+    data = json.dumps({
+        "title": f"[{payload.issue_type.upper()}] {payload.title}",
+        "body": issue_body,
+        "labels": _LABEL_MAP[payload.issue_type],
+    }).encode()
+
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo}/issues",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            issue = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = json.loads(e.read())
+        logger.error("GitHub API error: %s", body)
+        raise HTTPException(status_code=502, detail="Failed to create GitHub issue.")
+
+    return {"issue_number": issue["number"], "html_url": issue["html_url"]}
 
 
 # AWS Lambda entrypoint

--- a/backend/models.py
+++ b/backend/models.py
@@ -54,6 +54,16 @@ class MapCenter(BaseModel):
     zoom: float
 
 
+# ─── FEEDBACK / ISSUE CREATION ────────────────────────────────────────────────
+
+class CreateIssueRequest(BaseModel):
+    issue_type: Literal["bug", "feature", "enhancement", "question"]
+    title: str
+    body: str
+    priority: Literal["low", "medium", "high", "critical"]
+    submitter_name: str
+
+
 # ─── EXPORT REQUEST ───────────────────────────────────────────────────────────
 
 class ExportRequest(BaseModel):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from fastapi.testclient import TestClient
 
@@ -45,3 +46,26 @@ def test_export_pdf_no_signs(plan_no_signs):
     res = client.post("/export-pdf", json=plan_no_signs)
     assert res.status_code == 200
     assert res.content[:4] == b"%PDF"
+
+
+def test_create_issue_returns_503_when_token_missing(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    res = client.post("/create-issue", json={
+        "issue_type": "bug",
+        "title": "Test issue",
+        "body": "Test body",
+        "priority": "medium",
+        "submitter_name": "Tester",
+    })
+    assert res.status_code == 503
+
+
+def test_create_issue_validates_input():
+    res = client.post("/create-issue", json={
+        "issue_type": "invalid_type",
+        "title": "x",
+        "body": "x",
+        "priority": "medium",
+        "submitter_name": "x",
+    })
+    assert res.status_code == 422

--- a/my-app/public/feedback.html
+++ b/my-app/public/feedback.html
@@ -375,20 +375,16 @@
   </div>
 
   <div class="auth-notice">
-    <span class="badge">PLACEHOLDER</span>
-    <span>Auth check will go here — only verified tcplanpro.com account holders will be able to submit.</span>
+    <span class="badge">ALPHA</span>
+    <span>Access is currently gated by a shared alpha password (client-side only). Server-side auth for tcplanpro.com accounts will replace this before public launch.</span>
   </div>
 
   <details class="config-panel">
-    <summary>GitHub Configuration</summary>
+    <summary>API Configuration</summary>
     <div class="config-fields">
       <div>
-        <div class="config-label">GitHub Token (Fine-grained, issues:write)</div>
-        <input type="password" id="ghToken" placeholder="github_pat_..." />
-      </div>
-      <div>
-        <div class="config-label">Repository (owner/repo)</div>
-        <input type="text" id="ghRepo" value="jfisher94002/TrafficControlPlanner" />
+        <div class="config-label">Backend API Base URL</div>
+        <input type="text" id="apiBase" placeholder="https://api.example.com (leave blank for same origin)" />
       </div>
     </div>
   </details>
@@ -517,13 +513,6 @@
     selectedPriority = el.dataset.priority;
   }
 
-  const labelMap = {
-    bug:         ['bug', 'backlog'],
-    feature:     ['enhancement', 'feature request', 'backlog'],
-    enhancement: ['enhancement', 'backlog'],
-    question:    ['question', 'backlog']
-  };
-
   const typeDisplay = {
     bug: 'bug',
     feature: 'feature request',
@@ -531,11 +520,8 @@
     question: 'question'
   };
 
-  const priorityEmoji = { low: '🟢', medium: '🟡', high: '🟠', critical: '🔴' };
-
   async function submitIssue() {
-    const token = document.getElementById('ghToken').value.trim();
-    const repo = document.getElementById('ghRepo').value.trim();
+    const apiBase = (document.getElementById('apiBase').value.trim()).replace(/\/$/, '');
     const title = document.getElementById('issueTitle').value.trim();
     const body = document.getElementById('issueBody').value.trim();
     const name = document.getElementById('submitterName').value.trim();
@@ -543,50 +529,33 @@
 
     errorMsg.classList.remove('visible');
 
-    if (!token) return showError('Please enter your GitHub token in the configuration panel above.');
     if (!title) return showError('Please enter a title for the issue.');
     if (!body) return showError('Please enter a description.');
     if (!name) return showError('Please enter your name.');
 
     setLoading(true);
 
-    const issueBody = `## ${selectedType.charAt(0).toUpperCase() + selectedType.slice(1)} Report
-
-**Submitted by:** ${name}
-**Priority:** ${priorityEmoji[selectedPriority]} ${selectedPriority.charAt(0).toUpperCase() + selectedPriority.slice(1)}
-**Type:** ${selectedType}
-
----
-
-${body}
-
----
-*Submitted via TCP Feedback Portal*`;
-
     try {
-      const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      const res = await fetch(`${apiBase}/create-issue`, {
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'application/vnd.github+json',
-          'Content-Type': 'application/json',
-          'X-GitHub-Api-Version': '2022-11-28'
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          title: `[${selectedType.toUpperCase()}] ${title}`,
-          body: issueBody,
-          labels: labelMap[selectedType]
+          issue_type: selectedType,
+          title,
+          body,
+          priority: selectedPriority,
+          submitter_name: name,
         })
       });
 
       if (!res.ok) {
-        const err = await res.json();
-        throw new Error(err.message || `GitHub API error: ${res.status}`);
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.detail || `Server error ${res.status}`);
       }
 
       const issue = await res.json();
       document.getElementById('issueLink').href = issue.html_url;
-      document.getElementById('issueLink').textContent = `🔗 View Issue #${issue.number} on GitHub`;
+      document.getElementById('issueLink').textContent = `🔗 View Issue #${issue.issue_number} on GitHub`;
       document.getElementById('typepill').textContent = typeDisplay[selectedType];
       document.getElementById('formContent').classList.add('hidden');
       document.getElementById('successState').classList.add('visible');

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -1947,7 +1947,7 @@ export default function TrafficControlPlanner() {
           <button onClick={exportPNG} data-testid="export-png-button" style={{ ...panelBtnStyle(false), background: COLORS.accentDim, color: COLORS.accent, borderColor: "rgba(245,158,11,0.35)" }} title="Export canvas as PNG (2×)">↓ PNG</button>
           <button onClick={exportPDF} data-testid="export-pdf-button" style={{ ...panelBtnStyle(false), background: COLORS.accentDim, color: COLORS.accent, borderColor: "rgba(245,158,11,0.35)" }} title="Export plan as PDF">↓ PDF</button>
           <div style={{ width: 1, height: 24, background: COLORS.panelBorder }} />
-          <button onClick={() => window.open("/feedback.html", "_blank")} style={panelBtnStyle(false)} title="Report an issue or submit feedback">Report Issue</button>
+          <button onClick={() => window.open("/feedback.html", "_blank", "noopener,noreferrer")} style={panelBtnStyle(false)} title="Report an issue or submit feedback">Report Issue</button>
           <input ref={fileInputRef} type="file" accept=".json,.tcp.json" onChange={loadPlan} style={{ display: "none" }} />
         </div>
 


### PR DESCRIPTION
- my-app/public/feedback.html: TCP feedback portal with session-based password gate (TCP-alpha-2026), auth persists on refresh via sessionStorage
- toolbar: "Report Issue" button opens /feedback.html in a new tab, separated from export buttons by a divider

## Summary by Sourcery

Add a password-gated feedback portal page and expose it from the planner UI via a dedicated Report Issue button.

New Features:
- Introduce a standalone feedback portal HTML page that lets authenticated testers submit issues and feature requests directly to GitHub.
- Add a Report Issue toolbar button in the planner that opens the feedback portal in a new tab, visually separated from export actions.

Enhancements:
- Gate access to the feedback portal behind a session-based password check that persists for the browser session.