### PR TITLE
Add Cognito Identity Pool config for Amplify Storage (issue #76)

### DIFF
--- a/my-app/.env.example
+++ b/my-app/.env.example
@@ -4,6 +4,11 @@ VITE_AWS_REGION=us-east-1
 VITE_COGNITO_USER_POOL_ID=us-east-1_XXXXXXXXX
 VITE_COGNITO_APP_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
 
+# AWS Cognito Identity Pool — required for Amplify Storage (S3) credential provisioning
+# Console → Cognito → Identity Pools → your pool → Edit identity pool
+# Leave blank to disable cloud save/load even when S3 bucket is set
+VITE_COGNITO_IDENTITY_POOL_ID=us-east-1:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
 # AWS S3 — bucket for cloud plan storage (leave blank to disable cloud save/load)
 # Bucket must allow authenticated Cognito users to read/write under plans/{userId}/
 VITE_S3_BUCKET=your-tcp-plans-bucket

--- a/my-app/src/aws-exports.ts
+++ b/my-app/src/aws-exports.ts
@@ -6,12 +6,14 @@
  *
  * Leave aws_user_pools_id empty to run the app without authentication (dev mode).
  * Leave aws_user_files_s3_bucket empty to disable cloud save/load (dev mode).
+ * Leave aws_cognito_identity_pool_id empty to disable S3 credential provisioning.
  */
 const awsExports = {
   aws_project_region:              import.meta.env.VITE_AWS_REGION              || 'us-east-1',
   aws_cognito_region:              import.meta.env.VITE_AWS_REGION              || 'us-east-1',
   aws_user_pools_id:               import.meta.env.VITE_COGNITO_USER_POOL_ID    || '',
   aws_user_pools_web_client_id:    import.meta.env.VITE_COGNITO_APP_CLIENT_ID   || '',
+  aws_cognito_identity_pool_id:    import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID || '',
   aws_user_files_s3_bucket:        import.meta.env.VITE_S3_BUCKET               || '',
   aws_user_files_s3_bucket_region: import.meta.env.VITE_AWS_REGION              || 'us-east-1',
 }


### PR DESCRIPTION
## Summary
- Add `aws_cognito_identity_pool_id` to `aws-exports.ts` wired to `VITE_COGNITO_IDENTITY_POOL_ID`
- Add `VITE_COGNITO_IDENTITY_POOL_ID` to `.env.example` with format hint and instructions
- Update `aws-exports.ts` comment to document the new key

## AWS Console steps still required
Before cloud save/load will work in production, you need to:

1. **Create an Identity Pool** — AWS Console → Cognito → Identity Pools → Create
   - Enable access for authenticated users
   - Link to your User Pool (`VITE_COGNITO_USER_POOL_ID`) + App Client (`VITE_COGNITO_APP_CLIENT_ID`)

2. **IAM policy for the authenticated role** — add this inline policy:
   ```json
   {
     "Effect": "Allow",
     "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
     "Resource": "arn:aws:s3:::your-tcp-plans-bucket/plans/${cognito-identity.amazonaws.com:sub}/*"
   },
   {
     "Effect": "Allow",
     "Action": "s3:ListBucket",
     "Resource": "arn:aws:s3:::your-tcp-plans-bucket",
     "Condition": { "StringLike": { "s3:prefix": "plans/${cognito-identity.amazonaws.com:sub}/*" } }
   }
   ```

3. **Set env var** — add `VITE_COGNITO_IDENTITY_POOL_ID=us-east-1:your-pool-id` to your Amplify/deployment environment

## Test plan
- [ ] `npm run test` — 146/146 passing (no logic changes)
- [ ] `npm run build` — zero TypeScript errors
- [ ] Manual: sign in, click ☁ Save — plan saves without credential errors
- [ ] Manual: click ☁ Plans — plan appears in dashboard and can be opened

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire Cognito Identity Pool configuration into the Amplify storage setup and document the new environment variable.

New Features:
- Add support for configuring a Cognito Identity Pool ID for S3 credential provisioning via environment variables.

Documentation:
- Document the new VITE_COGNITO_IDENTITY_POOL_ID environment variable and its usage in configuration comments.