### PR TITLE
Add pre-beta banner and contact email (#137 #138)

### DIFF
--- a/my-app/.env.example
+++ b/my-app/.env.example
@@ -17,3 +17,6 @@ VITE_S3_BUCKET=your-tcp-plans-bucket
 # Get your key at posthog.com → Project Settings → Project API Key
 VITE_POSTHOG_KEY=
 
+# Contact/support email shown in the app header and pre-beta banner
+VITE_CONTACT_EMAIL=jfisher@fisherconsulting.org
+

--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -324,13 +324,15 @@ describe('PNG export', () => {
     ;(URL.revokeObjectURL as ReturnType<typeof vi.fn>).mockClear()
     const trackSpy = vi.spyOn(analytics, 'track')
 
+    // Render first so React's <a> elements are created before the spy is set up
+    const { user } = setup()
+
     const mockAnchor = { href: '', download: '', click: vi.fn() }
     const realCreateElement = document.createElement.bind(document)
     const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) =>
       tag === 'a' ? (mockAnchor as unknown as HTMLElement) : realCreateElement(tag),
     )
 
-    const { user } = setup()
     await user.click(screen.getByTestId('export-png-button'))
 
     expect(stageStub.toCanvas).toHaveBeenCalledWith({ pixelRatio: 2 })
@@ -542,6 +544,36 @@ describe('Auth props', () => {
     const signOutIdx = buttons.findIndex(b => b.getAttribute('data-testid') === 'sign-out-button')
     expect(signOutIdx).toBeGreaterThan(pngIdx)
     expect(signOutIdx).toBeGreaterThan(pdfIdx)
+  })
+})
+
+// ─── Pre-beta banner ──────────────────────────────────────────────────────────
+describe('Pre-beta banner', () => {
+  beforeEach(() => sessionStorage.clear())
+
+  it('shows the banner by default', () => {
+    render(<TrafficControlPlanner />)
+    expect(screen.getByTestId('prebeta-banner')).toBeInTheDocument()
+  })
+
+  it('hides the banner after clicking dismiss', async () => {
+    const user = userEvent.setup()
+    render(<TrafficControlPlanner />)
+    await user.click(screen.getByTestId('dismiss-banner'))
+    expect(screen.queryByTestId('prebeta-banner')).not.toBeInTheDocument()
+  })
+
+  it('does not show the banner if already dismissed this session', () => {
+    sessionStorage.setItem('tcp_prebeta_banner_dismissed', '1')
+    render(<TrafficControlPlanner />)
+    expect(screen.queryByTestId('prebeta-banner')).not.toBeInTheDocument()
+  })
+
+  it('contact email link is present in the toolbar', () => {
+    render(<TrafficControlPlanner />)
+    const link = screen.getByTestId('contact-email')
+    expect(link).toBeInTheDocument()
+    expect(link.getAttribute('href')).toMatch(/^mailto:/)
   })
 })
 

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -1683,6 +1683,8 @@ interface PlannerProps {
 }
 
 const CLOUD_ENABLED = Boolean(import.meta.env.VITE_S3_BUCKET && import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID);
+const CONTACT_EMAIL = (import.meta.env.VITE_CONTACT_EMAIL as string | undefined) || 'jfisher@fisherconsulting.org';
+const BANNER_KEY = 'tcp_prebeta_banner_dismissed';
 
 export default function TrafficControlPlanner({ userId = null, userEmail = null, onSignOut }: PlannerProps = {}) {
   const stageRef = useRef<Konva.Stage>(null);
@@ -1690,6 +1692,10 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
   // Read autosave once — reused by all useState initializers below
   const initialAutosave = useRef(readAutosave()).current;
+
+  const [bannerDismissed, setBannerDismissed] = useState(() => sessionStorage.getItem(BANNER_KEY) === '1');
+
+  const dismissBanner = () => { sessionStorage.setItem(BANNER_KEY, '1'); setBannerDismissed(true); };
 
   // Core state
   const [tool, setTool] = useState("select");
@@ -2484,6 +2490,17 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     <div style={{ width: "100%", height: "100vh", display: "flex", flexDirection: "column", background: COLORS.bg, color: COLORS.text, fontFamily: "'JetBrains Mono', 'SF Mono', 'Fira Code', monospace", overflow: "hidden", userSelect: "none" }}>
       <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
 
+      {/* ─── PRE-BETA BANNER ─── */}
+      {!bannerDismissed && (
+        <div data-testid="prebeta-banner" style={{ background: "rgba(245,158,11,0.15)", borderBottom: `1px solid rgba(245,158,11,0.35)`, padding: "6px 16px", display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0 }}>
+          <span style={{ fontSize: 11, color: COLORS.accent }}>
+            🚧 <strong>Pre-Beta</strong> — expect bugs and breaking changes. &nbsp;
+            <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: COLORS.accent, textDecoration: "underline" }}>Report an issue</a>
+          </span>
+          <button onClick={dismissBanner} data-testid="dismiss-banner" style={{ background: "none", border: "none", color: COLORS.textDim, cursor: "pointer", fontSize: 14, lineHeight: 1, padding: "0 4px" }} title="Dismiss">✕</button>
+        </div>
+      )}
+
       {/* ─── TOP BAR ─── */}
       <div style={{ height: 48, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 16px", borderBottom: `1px solid ${COLORS.panelBorder}`, background: COLORS.panel, flexShrink: 0, gap: 12 }}>
         <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: 1, minWidth: 0 }}>
@@ -2510,6 +2527,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
           <button onClick={exportPDF} data-testid="export-pdf-button" style={{ ...panelBtnStyle(false), background: COLORS.accentDim, color: COLORS.accent, borderColor: "rgba(245,158,11,0.35)" }} title="Export plan as PDF">↓ PDF</button>
           <div style={{ flex: 1 }} />
           <button onClick={() => window.open("/feedback.html", "_blank", "noopener,noreferrer")} style={panelBtnStyle(false)} title="Report an issue or submit feedback">Report Issue</button>
+          <a href={`mailto:${CONTACT_EMAIL}`} data-testid="contact-email" style={{ fontSize: 10, color: COLORS.textDim, textDecoration: "none", whiteSpace: "nowrap" }} title="Contact support">{CONTACT_EMAIL}</a>
           {onSignOut && (<>
             {(userEmail || userId) && (
               <span data-testid="user-identity" style={{ fontSize: 10, color: COLORS.textMuted, maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={userEmail ?? userId ?? ''}>


### PR DESCRIPTION
## Summary
- **#138 Pre-beta banner**: Amber dismissible bar at the top of the planner — "🚧 Pre-Beta — expect bugs and breaking changes" with a mailto: report link. Dismissed per session via `sessionStorage`, reappears on next visit.
- **#137 Contact email**: `jfisher@fisherconsulting.org` shown as a `mailto:` link in the top toolbar on every page. Configurable via `VITE_CONTACT_EMAIL` env var.

## Test plan
- [ ] 170 frontend tests pass (`npx vitest run`)
- [ ] Banner appears on load, dismisses on ✕ click, doesn't reappear in same session
- [ ] Contact email link visible in toolbar, opens mail client on click
- [ ] Add `VITE_CONTACT_EMAIL=jfisher@fisherconsulting.org` to Amplify env vars and redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a configurable pre-beta notification banner and a persistent contact email link to the planner UI.

New Features:
- Display a dismissible pre-beta banner at the top of the planner with a mailto link for reporting issues, persisted per session via sessionStorage.
- Show a contact email mailto link in the top toolbar on all planner pages, configurable via the VITE_CONTACT_EMAIL environment variable.

Tests:
- Add unit tests covering pre-beta banner visibility, dismissal behavior, per-session persistence, and presence of the contact email link in the toolbar.