### PR TITLE
Fix: sign out doesn't prevent auto-login on return to /app

### DIFF
--- a/my-app/src/App.test.tsx
+++ b/my-app/src/App.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 // vi.mock is hoisted — use vi.hoisted() for variables referenced inside factories
-const { mockAwsExports, mockSignOut, mockHubUnsubscribe, mockUseAuthenticator } = vi.hoisted(() => ({
+const { mockAwsExports, mockSignOut, mockAmplifySignOut, mockHubUnsubscribe, mockUseAuthenticator } = vi.hoisted(() => ({
   mockAwsExports: {
     aws_user_pools_id: '',
     aws_user_pools_web_client_id: '',
@@ -12,11 +12,17 @@ const { mockAwsExports, mockSignOut, mockHubUnsubscribe, mockUseAuthenticator } 
     aws_user_files_s3_bucket: '',
   },
   mockSignOut: vi.fn(),
+  mockAmplifySignOut: vi.fn(),
   mockHubUnsubscribe: vi.fn(),
   mockUseAuthenticator: vi.fn(),
 }))
 
 vi.mock('aws-amplify', () => ({ Amplify: { configure: vi.fn() } }))
+
+vi.mock('aws-amplify/auth', () => ({
+  signUp: vi.fn(),
+  signOut: mockAmplifySignOut,
+}))
 
 vi.mock('aws-amplify/utils', () => ({
   Hub: { listen: vi.fn(() => mockHubUnsubscribe) },
@@ -94,7 +100,7 @@ describe('App — auth enabled', () => {
   it('passes signOut as onSignOut to the planner', async () => {
     render(<App />)
     await userEvent.click(screen.getByTestId('sign-out-btn'))
-    expect(mockSignOut).toHaveBeenCalledOnce()
+    expect(mockAmplifySignOut).toHaveBeenCalledWith({ global: true })
   })
 
   it('registers a Hub auth listener on mount', () => {

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Amplify } from 'aws-amplify'
-import { signUp } from 'aws-amplify/auth'
+import { signUp, signOut as amplifySignOut } from 'aws-amplify/auth'
 import { Authenticator, ThemeProvider, useAuthenticator } from '@aws-amplify/ui-react'
 import '@aws-amplify/ui-react/styles.css'
 import TrafficControlPlanner from './traffic-control-planner'
@@ -47,7 +47,9 @@ function AuthedApp() {
 
   const handleSignOut = async () => {
     try {
-      await signOut()
+      // global: true revokes the Cognito refresh token server-side so the
+      // user isn't auto-signed back in when they return to /app.
+      await amplifySignOut({ global: true })
     } catch (err) {
       // Log so server-side session failures are visible in monitoring.
       console.error('[Auth] signOut error:', err)


### PR DESCRIPTION
## Problem

After signing out, clicking the CTA button and navigating back to `/app` automatically signs the user back in without prompting for credentials.

## Root Cause

`signOut()` from `useAuthenticator` only cleared local tokens (localStorage). The Cognito refresh token on the server remained valid. When the Amplify `Authenticator` mounted again, it found the still-valid server session and silently re-authenticated.

## Fix

Switch to `amplifySignOut({ global: true })` from `aws-amplify/auth`. The `global: true` flag revokes all refresh tokens on the Cognito server, making the sign-out complete.

```diff
- await signOut()  // useAuthenticator — local only
+ await amplifySignOut({ global: true })  // aws-amplify/auth — server + local
```

## Test plan
- [ ] Deploy to staging
- [ ] Sign in → Sign Out → click "Try TCP Plan Pro Free" → confirm login screen appears (not auto-signed in)
- [ ] Unit tests: 192/192 passing
- [ ] E2E sign-out test: `Sign Out > sign out redirects to landing page` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)