### PR TITLE
Fix: pass --repo to gh pr view before checkout exists

### DIFF
--- a/.github/workflows/ai-reviews.yml
+++ b/.github/workflows/ai-reviews.yml
@@ -44,6 +44,10 @@ jobs:
             BASE_REF="${{ github.base_ref }}"
           else
             BASE_REF=$(gh pr view ${{ inputs.pr_number }} --repo "${{ github.repository }}" --json baseRefName -q .baseRefName)
+            if [ -z "$BASE_REF" ]; then
+              echo "::error::Could not resolve baseRefName for PR ${{ inputs.pr_number }}"
+              exit 1
+            fi
           fi
           git fetch origin "$BASE_REF"
           git diff "origin/$BASE_REF"...HEAD > /tmp/pr.diff


### PR DESCRIPTION
## Summary
- `gh pr view` can't infer the repo when run before `actions/checkout` (no `.git` directory yet)
- Pass `--repo ${{ github.repository }}` explicitly to both `gh pr view` calls in the workflow

## Test plan
- [ ] Trigger "AI Code Review" workflow manually with `pr_number=146` — should resolve head ref and produce a real Gemini review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix GitHub CLI PR lookups in the AI review workflow by passing the repository explicitly when resolving head and base refs.