### PR TITLE
Fix editor placing wrong sign on canvas (issue #158)

### DIFF
--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -1139,7 +1139,7 @@ describe('Sign Editor', () => {
     expect(labels).toContain('ONE WAY')
   })
 
-  it('changing shape in editor updates the placed sign (verified via legend)', async () => {
+  it('changing shape in editor updates the placed sign — legend SVG uses circle element', async () => {
     const { user } = setup()
     // Arm sign tool first
     fireEvent.keyDown(window, { key: 'S' })
@@ -1147,8 +1147,12 @@ describe('Sign Editor', () => {
     // Select circle shape — editor label stays "CUSTOM"
     await user.click(screen.getByRole('button', { name: /circle/i }))
     fireEvent.mouseDown(screen.getByTestId('konva-stage'))
+    // Label is present
     const labels = screen.getAllByTestId('legend-item-label').map(l => l.textContent)
     expect(labels).toContain('CUSTOM')
+    // Legend SVG must contain a <circle> element (SignIconSvg renders one for circle shape)
+    const legendBox = screen.getByTestId('legend-box')
+    expect(legendBox.querySelector('circle')).toBeInTheDocument()
   })
 
   it('Place button activates sign tool so next canvas click places the editor sign', async () => {

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -989,7 +989,8 @@ function SignEditorPanel({ onUseSign, onSaveToLibrary, onSignChange }: SignEdito
   const previewRef = useRef<HTMLCanvasElement>(null);
 
   const signData = useMemo(() => ({
-    id: "custom_preview",
+    // Derive id from configuration so legend/analytics can distinguish different editor signs.
+    id: `custom_${shape}_${(text || " ").trim().toLowerCase().replace(/\s+/g, "_")}`,
     label: text || " ",
     shape,
     color: bgColor,
@@ -2896,7 +2897,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
                 {signSubTab === "editor" && (
                   <SignEditorPanel
-                    onSignChange={(signData) => setSelectedSign(signData)}
+                    onSignChange={setSelectedSign}
                     onUseSign={() => switchTool("sign")}
                     onSaveToLibrary={(signData) => {
                       const existing = customSigns.find((s) =>


### PR DESCRIPTION
## Root cause
`SignEditorPanel` manages its own local state (`shape`, `text`, colors) but never synced it back to the parent's `selectedSign` unless the user explicitly clicked **Place**. Clicking directly on the canvas would place whatever library sign was last selected — in the reporter's case, Ped Xing.

## Fix
- Added `onSignChange` prop to `SignEditorPanel`
- A `useEffect` fires `onSignChange(signData)` whenever the editor's sign changes, keeping `selectedSign` live-synced
- The **Place** button now just calls `switchTool("sign")` (no need to re-set selectedSign, it's already current)
- Clicking the canvas without clicking Place now correctly places the editor's current sign

## Test plan
- [ ] Open Signs → Editor, select Diamond, leave text as CUSTOM, click canvas → CUSTOM diamond placed
- [ ] Type "ONE WAY" in text field, click canvas without clicking Place → ONE WAY diamond placed
- [ ] Change shape to circle, click canvas → circle placed (not previous library sign)
- [ ] 216 unit tests pass

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Synchronize the sign editor with the currently selected sign so canvas placements always use the editor’s active sign design.

Bug Fixes:
- Ensure clicking the canvas places the sign currently configured in the editor instead of the last sign chosen from the library.

Enhancements:
- Propagate sign changes from the editor to the parent via a callback, simplifying the Place action to only switch tools.