### PR TITLE
Fix map tiles not showing after loading a plan from the dashboard

### DIFF
--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -2790,7 +2790,8 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     const newMeta = (data.metadata as PlanMeta | undefined) ?? { projectNumber: '', client: '', location: '', notes: '' };
     const newOffset = (data.canvasOffset as Point | undefined) ?? { x: 0, y: 0 };
     const newZoom = typeof data.canvasZoom === 'number' ? data.canvasZoom : 1;
-    const newMapCenter = (data.mapCenter as MapCenter | null | undefined) ?? null;
+    const rawMC = data.mapCenter as { lat: number; lng: number; zoom: number } | null | undefined;
+    const newMapCenter: MapCenter | null = rawMC ? { lat: rawMC.lat, lon: rawMC.lng, zoom: rawMC.zoom } : null;
     setPlanId(newId);
     setPlanTitle(newTitle);
     setPlanCreatedAt(newCreatedAt);


### PR DESCRIPTION
## Summary
- Map background tiles disappeared after loading a saved plan from the cloud dashboard
- Root cause: `mapCenter` is stored with `lng` (GeoJSON convention) but `handleDashboardOpen` was casting it directly as the internal `MapCenter` type which uses `lon` — leaving `lon` as `undefined` and skipping all tile rendering
- Fix mirrors the `lng → lon` remap already done correctly in `loadPlan` (local file load)

## Test plan
- [ ] Save a plan with a map location set
- [ ] Log out and back in, reload the plan from the dashboard
- [ ] Map tiles should appear at the correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct map center field mapping when loading a plan from the dashboard by converting stored lng coordinates into the internal lon format.