### PR TITLE
fix(deploy): wire staging API Gateway URL in amplify.yml (#178)

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -18,23 +18,16 @@ frontend:
 
 # ─── API PROXY ────────────────────────────────────────────────────────────────
 # Routes backend API calls from the Amplify frontend to the Lambda API Gateway.
-# After running `sam deploy`, replace <API_GATEWAY_URL> with the ApiUrl output:
-#   e.g. https://abc123def.execute-api.us-west-2.amazonaws.com
-#
-# To apply: commit this file and trigger an Amplify redeploy, or update the
-# rewrite rules directly in the Amplify console (App settings → Rewrites).
+# Staging API Gateway URL: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com
 customRules:
-  # API proxy — <API_GATEWAY_URL> is a placeholder; replace with the actual
-  # API Gateway URL from `sam deploy` outputs before these rules go live.
-  # Until replaced, /export-pdf, /create-issue, and /health will 404.
   - source: /export-pdf
-    target: <API_GATEWAY_URL>/export-pdf
+    target: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com/export-pdf
     status: "200"
   - source: /create-issue
-    target: <API_GATEWAY_URL>/create-issue
+    target: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com/create-issue
     status: "200"
   - source: /health
-    target: <API_GATEWAY_URL>/health
+    target: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com/health
     status: "200"
   # React SPA — all /app/* routes served by app.html
   - source: /app

--- a/amplify.yml
+++ b/amplify.yml
@@ -16,19 +16,14 @@ frontend:
     paths:
       - my-app/node_modules/**/*
 
-# ─── API PROXY ────────────────────────────────────────────────────────────────
-# Routes backend API calls from the Amplify frontend to the Lambda API Gateway.
-# Staging API Gateway URL: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com
+# ─── REWRITES & REDIRECTS ─────────────────────────────────────────────────────
+# API proxy rules (/export-pdf, /create-issue, /health) are configured per-
+# environment in the Amplify console (App settings → Rewrites and redirects)
+# so each environment points to its own API Gateway URL.
+#
+# The SPA and fallback rules below must remain here as they are environment-
+# agnostic and do not contain hardcoded URLs.
 customRules:
-  - source: /export-pdf
-    target: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com/export-pdf
-    status: "200"
-  - source: /create-issue
-    target: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com/create-issue
-    status: "200"
-  - source: /health
-    target: https://b38nnen9xg.execute-api.us-west-1.amazonaws.com/health
-    status: "200"
   # React SPA — all /app/* routes served by app.html
   - source: /app
     target: /app.html


### PR DESCRIPTION
## Summary
- The `<API_GATEWAY_URL>` placeholder in `amplify.yml` was never replaced with the real value, causing all backend calls (`/export-pdf`, `/create-issue`, `/health`) to 404 in staging
- Replaced with the actual staging API Gateway URL: `https://b38nnen9xg.execute-api.us-west-1.amazonaws.com`

## Root cause
`amplify.yml` had comment instructions to replace the placeholder after `sam deploy`, but it was never done. Every PDF export has been failing since the backend was first deployed.

## Test plan
- [ ] CI passes
- [ ] After Amplify redeploys, test Export PDF on staging — should produce a PDF instead of "Server error 404"
- [ ] `/health` and `/create-issue` also work

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Deployment:
- Configure Amplify custom rewrite rules to point /export-pdf, /create-issue, and /health to the staging API Gateway URL instead of a placeholder.