### PR TITLE
feat(feedback): SES notification email with Reply-To submitter address

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,9 @@ import os
 import urllib.error
 import urllib.request
 
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
@@ -163,8 +166,6 @@ def _send_feedback_email(payload: CreateIssueRequest, issue_number: int, issue_u
         send_kwargs["ReplyToAddresses"] = [payload.submitter_email]
 
     try:
-        import boto3
-        from botocore.exceptions import BotoCoreError, ClientError
         ses_kwargs: dict = {}
         ses_region = os.getenv("AWS_SES_REGION")
         if ses_region:

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,9 +4,6 @@ import os
 import urllib.error
 import urllib.request
 
-import boto3
-from botocore.exceptions import ClientError
-
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
@@ -166,9 +163,15 @@ def _send_feedback_email(payload: CreateIssueRequest, issue_number: int, issue_u
         send_kwargs["ReplyToAddresses"] = [payload.submitter_email]
 
     try:
-        ses = boto3.client("ses", region_name=os.getenv("AWS_SES_REGION", "us-west-1"))
+        import boto3
+        from botocore.exceptions import BotoCoreError, ClientError
+        ses_kwargs: dict = {}
+        ses_region = os.getenv("AWS_SES_REGION")
+        if ses_region:
+            ses_kwargs["region_name"] = ses_region
+        ses = boto3.client("ses", **ses_kwargs)
         ses.send_email(**send_kwargs)
-    except ClientError:
+    except (ClientError, BotoCoreError, Exception):
         logger.exception("SES email failed — continuing")
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,9 @@ import os
 import urllib.error
 import urllib.request
 
+import boto3
+from botocore.exceptions import ClientError
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
@@ -121,7 +124,52 @@ def create_issue(payload: CreateIssueRequest):
         logger.error("GitHub API error: %s", body)
         raise HTTPException(status_code=502, detail="Failed to create GitHub issue.")
 
+    _send_feedback_email(payload, issue["number"], issue["html_url"])
+
     return {"issue_number": issue["number"], "html_url": issue["html_url"]}
+
+
+def _send_feedback_email(payload: CreateIssueRequest, issue_number: int, issue_url: str) -> None:
+    """Send a notification email via SES. Non-fatal — logs errors but never raises."""
+    sender = os.getenv("SES_SENDER_EMAIL", "")
+    if not sender:
+        return
+
+    subject = f"[TCP Feedback #{issue_number}] {payload.title}"
+    body_lines = [
+        f"New feedback submitted via TCP Plan Pro.",
+        "",
+        f"Issue: {issue_url}",
+        f"Type: {payload.issue_type}",
+        f"Priority: {payload.priority}",
+        f"Submitted by: {payload.submitter_name}",
+    ]
+    if payload.submitter_email:
+        body_lines.append(f"Submitter email: {payload.submitter_email}")
+    body_lines += [
+        "",
+        "--- Feedback ---",
+        payload.body,
+    ]
+    body_text = "\n".join(body_lines)
+
+    message: dict = {
+        "Subject": {"Data": subject, "Charset": "UTF-8"},
+        "Body": {"Text": {"Data": body_text, "Charset": "UTF-8"}},
+    }
+    send_kwargs: dict = {
+        "Source": sender,
+        "Destination": {"ToAddresses": [sender]},
+        "Message": message,
+    }
+    if payload.submitter_email:
+        send_kwargs["ReplyToAddresses"] = [payload.submitter_email]
+
+    try:
+        ses = boto3.client("ses", region_name=os.getenv("AWS_SES_REGION", "us-west-1"))
+        ses.send_email(**send_kwargs)
+    except ClientError:
+        logger.exception("SES email failed — continuing")
 
 
 # AWS Lambda entrypoint

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,4 +1,6 @@
 -r requirements.txt
+boto3==1.38.0
 httpx==0.28.1
 pytest==8.3.4
 pytest-cov==6.0.0
+moto[ses]==5.1.3

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -3,4 +3,3 @@ boto3==1.38.0
 httpx==0.28.1
 pytest==8.3.4
 pytest-cov==6.0.0
-moto[ses]==5.1.3

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-boto3==1.38.0
 httpx==0.28.1
 pytest==8.3.4
 pytest-cov==6.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 # python 3.12
+boto3==1.38.0
 fastapi==0.115.5
 mangum==0.17.0
 pydantic==2.10.3

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -16,6 +16,9 @@ Globals:
         ASSETS_BUCKET: !Ref TcpAssetsBucket
         SES_SENDER_EMAIL: !Ref SesSenderEmail
 
+Conditions:
+  HasSesSenderEmail: !Not [!Equals [!Ref SesSenderEmail, ""]]
+
 Parameters:
   Stage:
     Type: String
@@ -61,10 +64,13 @@ Resources:
       Policies:
         - S3ReadPolicy:
             BucketName: !Ref TcpAssetsBucket
-        - Statement:
-            - Effect: Allow
-              Action: ses:SendEmail
-              Resource: !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${SesSenderEmail}"
+        - !If
+          - HasSesSenderEmail
+          - Statement:
+              - Effect: Allow
+                Action: ses:SendEmail
+                Resource: !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${SesSenderEmail}"
+          - !Ref AWS::NoValue
 
   TcpAssetsBucket:
     Type: AWS::S3::Bucket

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -14,6 +14,7 @@ Globals:
         GITHUB_TOKEN: !Ref GitHubToken
         GITHUB_REPO: !Ref GitHubRepo
         ASSETS_BUCKET: !Ref TcpAssetsBucket
+        SES_SENDER_EMAIL: !Ref SesSenderEmail
 
 Parameters:
   Stage:
@@ -33,6 +34,10 @@ Parameters:
     Type: String
     Default: "jfisher94002/TrafficControlPlanner"
     Description: "GitHub repo for feedback issue creation (owner/repo)"
+  SesSenderEmail:
+    Type: String
+    Default: ""
+    Description: "SES-verified From/To address for feedback notifications (e.g. jfisher@fisherconsulting.org)"
 
 Resources:
 
@@ -56,6 +61,10 @@ Resources:
       Policies:
         - S3ReadPolicy:
             BucketName: !Ref TcpAssetsBucket
+        - Statement:
+            - Effect: Allow
+              Action: ses:SendEmail
+              Resource: "*"
 
   TcpAssetsBucket:
     Type: AWS::S3::Bucket

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -64,7 +64,7 @@ Resources:
         - Statement:
             - Effect: Allow
               Action: ses:SendEmail
-              Resource: "*"
+              Resource: !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${SesSenderEmail}"
 
   TcpAssetsBucket:
     Type: AWS::S3::Bucket

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,6 +1,7 @@
 import os
 import re
 import pytest
+from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 
 from main import app
@@ -456,3 +457,105 @@ def test_pdf_legend_with_signs_and_devices(sample_plan):
     res = client.post("/export-pdf", json=sample_plan)
     assert res.status_code == 200
     assert res.content[:4] == b"%PDF"
+
+
+# ─── SES email notification tests ────────────────────────────────────────────
+
+def _mock_urlopen_success():
+    mock_resp = MagicMock()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.read.return_value = b'{"number": 42, "html_url": "https://github.com/x/y/issues/42"}'
+    return mock_resp
+
+
+def test_ses_not_called_when_sender_not_configured(monkeypatch):
+    """When SES_SENDER_EMAIL is unset, no boto3 call should be made."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.delenv("SES_SENDER_EMAIL", raising=False)
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
+         patch("boto3.client") as mock_boto:
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "t", "body": "b",
+            "priority": "medium", "submitter_name": "Tester",
+            "submitter_email": "user@example.com", "submitter_id": "u-1",
+        })
+    assert res.status_code == 200
+    mock_boto.assert_not_called()
+
+
+def test_ses_sends_email_with_reply_to_when_email_provided(monkeypatch):
+    """When submitter_email is present, Reply-To should be set to that address."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
+    mock_ses = MagicMock()
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
+         patch("boto3.client", return_value=mock_ses):
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "t", "body": "b",
+            "priority": "medium", "submitter_name": "Tester",
+            "submitter_email": "user@example.com", "submitter_id": "u-1",
+        })
+    assert res.status_code == 200
+    mock_ses.send_email.assert_called_once()
+    call_kwargs = mock_ses.send_email.call_args[1]
+    assert call_kwargs["ReplyToAddresses"] == ["user@example.com"]
+    assert call_kwargs["Source"] == "jfisher@fisherconsulting.org"
+    assert call_kwargs["Destination"]["ToAddresses"] == ["jfisher@fisherconsulting.org"]
+
+
+def test_ses_no_reply_to_when_no_submitter_email(monkeypatch):
+    """When submitter_email is absent, no Reply-To header should be set."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
+    mock_ses = MagicMock()
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
+         patch("boto3.client", return_value=mock_ses):
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "t", "body": "b",
+            "priority": "medium", "submitter_name": "Tester",
+            "submitter_id": "u-1",
+        })
+    assert res.status_code == 200
+    mock_ses.send_email.assert_called_once()
+    call_kwargs = mock_ses.send_email.call_args[1]
+    assert "ReplyToAddresses" not in call_kwargs
+
+
+def test_ses_failure_does_not_break_issue_creation(monkeypatch):
+    """SES errors must be swallowed — issue creation should still return 200."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
+    mock_ses = MagicMock()
+    from botocore.exceptions import ClientError
+    mock_ses.send_email.side_effect = ClientError(
+        {"Error": {"Code": "MessageRejected", "Message": "Email address not verified"}}, "SendEmail"
+    )
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
+         patch("boto3.client", return_value=mock_ses):
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "t", "body": "b",
+            "priority": "medium", "submitter_name": "Tester",
+            "submitter_email": "user@example.com", "submitter_id": "u-1",
+        })
+    assert res.status_code == 200
+    assert res.json()["issue_number"] == 42
+
+
+def test_ses_email_subject_contains_issue_number_and_title(monkeypatch):
+    """Email subject should reference the GitHub issue number and feedback title."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
+    mock_ses = MagicMock()
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
+         patch("boto3.client", return_value=mock_ses):
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "Map crashes on zoom", "body": "b",
+            "priority": "high", "submitter_name": "Tester",
+            "submitter_email": "user@example.com", "submitter_id": "u-1",
+        })
+    assert res.status_code == 200
+    call_kwargs = mock_ses.send_email.call_args[1]
+    subject = call_kwargs["Message"]["Subject"]["Data"]
+    assert "42" in subject
+    assert "Map crashes on zoom" in subject

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -272,8 +272,8 @@ def test_md_escape_strips_newlines(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
     from unittest.mock import patch, MagicMock
     mock_resp = MagicMock()
-    mock_resp.__enter__ = lambda s: s
-    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
     mock_resp.read.return_value = b'{"number": 1, "html_url": "https://github.com/x"}'
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
         res = client.post("/create-issue", json={
@@ -299,8 +299,8 @@ def test_md_escape_escapes_markdown_special_chars(monkeypatch):
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
     from unittest.mock import patch, MagicMock
     mock_resp = MagicMock()
-    mock_resp.__enter__ = lambda s: s
-    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
     mock_resp.read.return_value = b'{"number": 1, "html_url": "https://github.com/x"}'
     with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
         res = client.post("/create-issue", json={
@@ -463,8 +463,8 @@ def test_pdf_legend_with_signs_and_devices(sample_plan):
 
 def _mock_urlopen_success():
     mock_resp = MagicMock()
-    mock_resp.__enter__ = lambda s: s
-    mock_resp.__exit__ = MagicMock(return_value=False)
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
     mock_resp.read.return_value = b'{"number": 42, "html_url": "https://github.com/x/y/issues/42"}'
     return mock_resp
 
@@ -542,15 +542,15 @@ def test_ses_failure_does_not_break_issue_creation(monkeypatch):
     assert res.json()["issue_number"] == 42
 
 
-def test_ses_email_subject_contains_issue_number_and_title(monkeypatch):
-    """Email subject should reference the GitHub issue number and feedback title."""
+def test_ses_email_subject_and_body_content(monkeypatch):
+    """Email subject and body should include issue number, title, URL, and feedback."""
     monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
     monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
     mock_ses = MagicMock()
     with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
          patch("boto3.client", return_value=mock_ses):
         res = client.post("/create-issue", json={
-            "issue_type": "bug", "title": "Map crashes on zoom", "body": "b",
+            "issue_type": "bug", "title": "Map crashes on zoom", "body": "Steps to repro here",
             "priority": "high", "submitter_name": "Tester",
             "submitter_email": "user@example.com", "submitter_id": "u-1",
         })
@@ -559,3 +559,45 @@ def test_ses_email_subject_contains_issue_number_and_title(monkeypatch):
     subject = call_kwargs["Message"]["Subject"]["Data"]
     assert "42" in subject
     assert "Map crashes on zoom" in subject
+    body = call_kwargs["Message"]["Body"]["Text"]["Data"]
+    assert "https://github.com/x/y/issues/42" in body
+    assert "bug" in body
+    assert "high" in body
+    assert "Submitter email: user@example.com" in body
+    assert "--- Feedback ---" in body
+    assert "Steps to repro here" in body
+
+
+def test_ses_body_omits_submitter_email_line_when_absent(monkeypatch):
+    """Email body should not include 'Submitter email:' when no email was provided."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
+    mock_ses = MagicMock()
+    with patch("urllib.request.urlopen", return_value=_mock_urlopen_success()), \
+         patch("boto3.client", return_value=mock_ses):
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "t", "body": "b",
+            "priority": "medium", "submitter_name": "Tester", "submitter_id": "u-1",
+        })
+    assert res.status_code == 200
+    body = mock_ses.send_email.call_args[1]["Message"]["Body"]["Text"]["Data"]
+    assert "Submitter email:" not in body
+
+
+def test_ses_not_called_when_github_fails(monkeypatch):
+    """SES must not be called if GitHub issue creation fails."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake-token")
+    monkeypatch.setenv("SES_SENDER_EMAIL", "jfisher@fisherconsulting.org")
+    import io, urllib.error
+    mock_fp = io.BytesIO(b'{"message": "Internal Server Error"}')
+    mock_ses = MagicMock()
+    with patch("urllib.request.urlopen", side_effect=urllib.error.HTTPError(
+        url=None, code=500, msg="Server Error", hdrs=None, fp=mock_fp
+    )), patch("boto3.client", return_value=mock_ses):
+        res = client.post("/create-issue", json={
+            "issue_type": "bug", "title": "t", "body": "b",
+            "priority": "medium", "submitter_name": "Tester",
+            "submitter_email": "user@example.com", "submitter_id": "u-1",
+        })
+    assert res.status_code == 502
+    mock_ses.send_email.assert_not_called()


### PR DESCRIPTION
## Summary
- When feedback is submitted with an email address, `/create-issue` now sends a notification email to `jfisher@fisherconsulting.org` via SES with `Reply-To` set to the submitter's email — so you can reply directly to the user without copying the address from the GitHub issue
- SES errors are non-fatal: if the email fails, the GitHub issue is still created and 200 is returned
- Adds `SES_SENDER_EMAIL` parameter to SAM template and `ses:SendEmail` IAM policy
- No email is sent if `SES_SENDER_EMAIL` env var is not configured

## Pre-deploy step required
The sender identity (`jfisher@fisherconsulting.org`) must be verified in SES before deploying. A verification email was sent — **click the link in that email first**, then redeploy with:
```
sam deploy --parameter-overrides SesSenderEmail=jfisher@fisherconsulting.org ...
```

## Test plan
- [x] 47 backend pytest tests pass (5 new SES-specific tests)
- [ ] After verifying SES identity and redeploying: submit feedback with an email on staging → confirm notification arrives at jfisher@fisherconsulting.org with Reply-To set correctly

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add SES-based notification emails when feedback issues are created, while keeping issue creation resilient to email failures.

New Features:
- Send SES notification emails to a configured sender address when /create-issue creates a new GitHub feedback issue, optionally setting Reply-To to the submitter's email.
- Introduce a configurable SES_SENDER_EMAIL parameter/env var and wire it into the Lambda environment and IAM permissions for sending feedback notifications.

Enhancements:
- Ensure SES email failures are swallowed so GitHub issue creation still succeeds and returns a 200 response.

Tests:
- Add backend tests covering SES notification behavior, including when the sender email is unset, Reply-To handling, subject formatting, and graceful handling of SES failures.