### PR TITLE
feat(auth): move sign-in gate from app entry to PDF export

### DIFF
--- a/my-app/src/App.test.tsx
+++ b/my-app/src/App.test.tsx
@@ -1,20 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 
 // vi.mock is hoisted — use vi.hoisted() for variables referenced inside factories
-const { mockAwsExports, mockSignOut, mockAmplifySignOut, mockHubUnsubscribe, mockUseAuthenticator } = vi.hoisted(() => ({
+const { mockAwsExports, mockAmplifySignOut, mockHubUnsubscribe, mockGetCurrentUser } = vi.hoisted(() => ({
   mockAwsExports: {
     aws_user_pools_id: '',
     aws_user_pools_web_client_id: '',
     aws_cognito_identity_pool_id: '',
     aws_user_files_s3_bucket: '',
   },
-  mockSignOut: vi.fn(),
-  mockAmplifySignOut: vi.fn(),
+  mockAmplifySignOut: vi.fn().mockResolvedValue(undefined),
   mockHubUnsubscribe: vi.fn(),
-  mockUseAuthenticator: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
 }))
 
 vi.mock('aws-amplify', () => ({ Amplify: { configure: vi.fn() } }))
@@ -22,6 +21,7 @@ vi.mock('aws-amplify', () => ({ Amplify: { configure: vi.fn() } }))
 vi.mock('aws-amplify/auth', () => ({
   signUp: vi.fn(),
   signOut: mockAmplifySignOut,
+  getCurrentUser: mockGetCurrentUser,
 }))
 
 vi.mock('aws-amplify/utils', () => ({
@@ -32,18 +32,28 @@ vi.mock('./aws-exports', () => ({ default: mockAwsExports }))
 
 vi.mock('@aws-amplify/ui-react', () => ({
   Authenticator: ({ children }: { children: (ctx: unknown) => React.ReactNode }) =>
-    children({ user: null, signOut: mockSignOut }),
+    children({ user: null, signOut: vi.fn() }),
   ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   createTheme: vi.fn(() => ({})),
-  useAuthenticator: () => mockUseAuthenticator(),
 }))
 
 vi.mock('./traffic-control-planner', () => ({
-  default: ({ userId, userEmail, onSignOut }: { userId?: string | null; userEmail?: string | null; onSignOut?: () => void }) => (
+  default: ({
+    userId,
+    userEmail,
+    onSignOut,
+    onRequestSignIn,
+  }: {
+    userId?: string | null
+    userEmail?: string | null
+    onSignOut?: () => void
+    onRequestSignIn?: () => void
+  }) => (
     <div data-testid="planner">
       <span data-testid="prop-userId">{userId ?? 'null'}</span>
       <span data-testid="prop-userEmail">{userEmail ?? 'null'}</span>
       {onSignOut && <button data-testid="sign-out-btn" onClick={onSignOut}>Sign Out</button>}
+      {onRequestSignIn && <button data-testid="request-sign-in-btn" onClick={onRequestSignIn}>Export PDF</button>}
     </div>
   ),
 }))
@@ -52,6 +62,12 @@ import App from './App'
 import { Hub } from 'aws-amplify/utils'
 
 describe('App — auth disabled (no Cognito config)', () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockRejectedValue(new Error('not signed in'))
+  })
+
+  afterEach(() => { vi.clearAllMocks() })
+
   it('renders the planner without auth', () => {
     render(<App />)
     expect(screen.getByTestId('planner')).toBeInTheDocument()
@@ -72,13 +88,8 @@ describe('App — auth enabled', () => {
   beforeEach(() => {
     mockAwsExports.aws_user_pools_id = 'us-east-1_TESTPOOL'
     mockAwsExports.aws_user_pools_web_client_id = 'testclientid123'
-    mockUseAuthenticator.mockReturnValue({
-      user: {
-        username: 'cognito-uuid-abc123',
-        signInDetails: { loginId: 'user@example.com' },
-      },
-      signOut: mockSignOut,
-    })
+    // Default: no active session
+    mockGetCurrentUser.mockRejectedValue(new Error('not signed in'))
   })
 
   afterEach(() => {
@@ -87,20 +98,53 @@ describe('App — auth enabled', () => {
     vi.clearAllMocks()
   })
 
-  it('passes userEmail (loginId) to the planner', () => {
+  it('renders the planner immediately (no auth gate)', () => {
     render(<App />)
-    expect(screen.getByTestId('prop-userEmail').textContent).toBe('user@example.com')
+    expect(screen.getByTestId('planner')).toBeInTheDocument()
   })
 
-  it('passes userId (cognito username) to the planner', () => {
+  it('passes userId=null and userEmail=null when not signed in', () => {
     render(<App />)
-    expect(screen.getByTestId('prop-userId').textContent).toBe('cognito-uuid-abc123')
+    expect(screen.getByTestId('prop-userId').textContent).toBe('null')
+    expect(screen.getByTestId('prop-userEmail').textContent).toBe('null')
   })
 
-  it('passes signOut as onSignOut to the planner', async () => {
+  it('restores session from getCurrentUser on mount', async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      username: 'cognito-uuid-abc123',
+      signInDetails: { loginId: 'user@example.com' },
+    })
     render(<App />)
-    await userEvent.click(screen.getByTestId('sign-out-btn'))
-    expect(mockAmplifySignOut).toHaveBeenCalledWith({ global: true })
+    await waitFor(() => {
+      expect(screen.getByTestId('prop-userId').textContent).toBe('cognito-uuid-abc123')
+      expect(screen.getByTestId('prop-userEmail').textContent).toBe('user@example.com')
+    })
+  })
+
+  it('shows sign-out button only after user is identified', async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      username: 'cognito-uuid-abc123',
+      signInDetails: { loginId: 'user@example.com' },
+    })
+    render(<App />)
+    await waitFor(() => {
+      expect(screen.getByTestId('sign-out-btn')).toBeInTheDocument()
+    })
+  })
+
+  it('updates userId/userEmail on Hub signedIn event', async () => {
+    render(<App />)
+    const hubListener = vi.mocked(Hub.listen).mock.calls[0][1] as (e: { payload: { event: string; data?: unknown } }) => void
+    hubListener({
+      payload: {
+        event: 'signedIn',
+        data: { username: 'hub-user-id', signInDetails: { loginId: 'hub@example.com' } },
+      },
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('prop-userId').textContent).toBe('hub-user-id')
+      expect(screen.getByTestId('prop-userEmail').textContent).toBe('hub@example.com')
+    })
   })
 
   it('registers a Hub auth listener on mount', () => {
@@ -114,10 +158,23 @@ describe('App — auth enabled', () => {
     expect(mockHubUnsubscribe).toHaveBeenCalled()
   })
 
-  it('calls signOut when tokenRefresh_failure fires', () => {
+  it('calls amplifySignOut on tokenRefresh_failure', async () => {
     render(<App />)
     const hubListener = vi.mocked(Hub.listen).mock.calls[0][1] as (e: { payload: { event: string } }) => void
     hubListener({ payload: { event: 'tokenRefresh_failure' } })
-    expect(mockSignOut).toHaveBeenCalledOnce()
+    await waitFor(() => {
+      expect(mockAmplifySignOut).toHaveBeenCalledWith({ global: true })
+    })
+  })
+
+  it('passes onRequestSignIn to the planner', () => {
+    render(<App />)
+    expect(screen.getByTestId('request-sign-in-btn')).toBeInTheDocument()
+  })
+
+  it('shows sign-in modal when onRequestSignIn is called', async () => {
+    render(<App />)
+    await userEvent.click(screen.getByTestId('request-sign-in-btn'))
+    expect(screen.getByText('Sign in to export your plan as PDF')).toBeInTheDocument()
   })
 })

--- a/my-app/src/App.test.tsx
+++ b/my-app/src/App.test.tsx
@@ -58,6 +58,11 @@ vi.mock('./traffic-control-planner', () => ({
   ),
 }))
 
+vi.mock('./auth/SignInModal', () => ({
+  SignInModal: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? <div data-testid="sign-in-modal"><button onClick={onClose}>Close</button></div> : null,
+}))
+
 import App from './App'
 import { Hub } from 'aws-amplify/utils'
 
@@ -88,7 +93,6 @@ describe('App — auth enabled', () => {
   beforeEach(() => {
     mockAwsExports.aws_user_pools_id = 'us-east-1_TESTPOOL'
     mockAwsExports.aws_user_pools_web_client_id = 'testclientid123'
-    // Default: no active session
     mockGetCurrentUser.mockRejectedValue(new Error('not signed in'))
   })
 
@@ -121,7 +125,7 @@ describe('App — auth enabled', () => {
     })
   })
 
-  it('shows sign-out button only after user is identified', async () => {
+  it('shows sign-out button after session is restored', async () => {
     mockGetCurrentUser.mockResolvedValue({
       username: 'cognito-uuid-abc123',
       signInDetails: { loginId: 'user@example.com' },
@@ -130,6 +134,17 @@ describe('App — auth enabled', () => {
     await waitFor(() => {
       expect(screen.getByTestId('sign-out-btn')).toBeInTheDocument()
     })
+  })
+
+  it('registers a Hub auth listener on mount', () => {
+    render(<App />)
+    expect(Hub.listen).toHaveBeenCalledWith('auth', expect.any(Function))
+  })
+
+  it('unsubscribes Hub listener on unmount', () => {
+    const { unmount } = render(<App />)
+    unmount()
+    expect(mockHubUnsubscribe).toHaveBeenCalled()
   })
 
   it('updates userId/userEmail on Hub signedIn event', async () => {
@@ -145,17 +160,6 @@ describe('App — auth enabled', () => {
       expect(screen.getByTestId('prop-userId').textContent).toBe('hub-user-id')
       expect(screen.getByTestId('prop-userEmail').textContent).toBe('hub@example.com')
     })
-  })
-
-  it('registers a Hub auth listener on mount', () => {
-    render(<App />)
-    expect(Hub.listen).toHaveBeenCalledWith('auth', expect.any(Function))
-  })
-
-  it('unsubscribes Hub listener on unmount', () => {
-    const { unmount } = render(<App />)
-    unmount()
-    expect(mockHubUnsubscribe).toHaveBeenCalled()
   })
 
   it('calls amplifySignOut on tokenRefresh_failure', async () => {
@@ -175,6 +179,13 @@ describe('App — auth enabled', () => {
   it('shows sign-in modal when onRequestSignIn is called', async () => {
     render(<App />)
     await userEvent.click(screen.getByTestId('request-sign-in-btn'))
-    expect(screen.getByText('Sign in to export your plan as PDF')).toBeInTheDocument()
+    expect(screen.getByTestId('sign-in-modal')).toBeInTheDocument()
+  })
+
+  it('hides sign-in modal after sign-out button is clicked inside modal', async () => {
+    render(<App />)
+    await userEvent.click(screen.getByTestId('request-sign-in-btn'))
+    await userEvent.click(screen.getByText('Close'))
+    expect(screen.queryByTestId('sign-in-modal')).not.toBeInTheDocument()
   })
 })

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,97 +1,19 @@
-import { useEffect, useState, useCallback } from 'react'
 import { Amplify } from 'aws-amplify'
-import { signUp, signOut as amplifySignOut, getCurrentUser } from 'aws-amplify/auth'
-import { Hub } from 'aws-amplify/utils'
-import { Authenticator, ThemeProvider } from '@aws-amplify/ui-react'
+import { ThemeProvider } from '@aws-amplify/ui-react'
 import '@aws-amplify/ui-react/styles.css'
 import TrafficControlPlanner from './traffic-control-planner'
 import awsExports from './aws-exports'
 import { authTheme } from './auth/theme'
-import { AuthHeader } from './auth/AuthHeader'
-import { identifyUser, resetAnalytics } from './analytics'
+import { useAuthSession } from './auth/useAuthSession'
+import { SignInModal } from './auth/SignInModal'
 
 Amplify.configure(awsExports)
-
-// Amplify UI doesn't always forward custom formFields to Cognito automatically.
-// This ensures `name` from the sign-up form is included in the signUp call.
-const authServices = {
-  async handleSignUp(input: Parameters<typeof signUp>[0]) {
-    const attrs = (input.options?.userAttributes ?? {}) as Record<string, string>
-    const name = attrs['name'] ?? ''
-    return signUp({
-      ...input,
-      options: {
-        ...input.options,
-        userAttributes: { ...attrs, name },
-      },
-    })
-  },
-}
-
-const signInFormFields = {
-  signUp: {
-    name: {
-      label: 'Full Name',
-      placeholder: 'Enter your full name',
-      isRequired: true,
-      order: 1,
-    },
-    email: { order: 2 },
-    password: { order: 3 },
-    confirm_password: { order: 4 },
-  },
-}
 
 export default function App() {
   // Evaluated at render time so test mocks can override the config object
   const AUTH_ENABLED = Boolean(awsExports.aws_user_pools_id && awsExports.aws_user_pools_web_client_id)
 
-  const [userId, setUserId]       = useState<string | null>(null)
-  const [userEmail, setUserEmail] = useState<string | null>(null)
-  const [showSignIn, setShowSignIn] = useState(false)
-
-  useEffect(() => {
-    if (!AUTH_ENABLED) return
-
-    // Restore session if user is already signed in
-    getCurrentUser()
-      .then(u => {
-        const email = u.signInDetails?.loginId ?? null
-        setUserId(u.username)
-        setUserEmail(email)
-        identifyUser(u.username, email)
-      })
-      .catch(() => { /* not signed in — that's fine */ })
-
-    // React to auth events: sign-in, sign-out, token refresh failures
-    const unsubscribe = Hub.listen('auth', ({ payload }) => {
-      if (payload.event === 'signedIn') {
-        const u = payload.data as { username: string; signInDetails?: { loginId?: string } }
-        const email = u.signInDetails?.loginId ?? null
-        setUserId(u.username)
-        setUserEmail(email)
-        setShowSignIn(false)
-        identifyUser(u.username, email)
-      } else if (payload.event === 'signedOut') {
-        setUserId(null)
-        setUserEmail(null)
-        resetAnalytics()
-      } else if (payload.event === 'tokenRefresh_failure') {
-        handleSignOut()
-      }
-    })
-    return unsubscribe
-  }, [AUTH_ENABLED]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const handleSignOut = useCallback(async () => {
-    try {
-      await amplifySignOut({ global: true })
-    } catch (err) {
-      console.error('[Auth] signOut error:', err)
-    } finally {
-      window.location.href = '/'
-    }
-  }, [])
+  const { userId, userEmail, showSignIn, openSignIn, closeSignIn, handleSignOut } = useAuthSession(AUTH_ENABLED)
 
   if (!AUTH_ENABLED) {
     return <TrafficControlPlanner userId={null} />
@@ -103,46 +25,9 @@ export default function App() {
         userId={userId}
         userEmail={userEmail}
         onSignOut={userId ? handleSignOut : undefined}
-        onRequestSignIn={() => setShowSignIn(true)}
+        onRequestSignIn={openSignIn}
       />
-
-      {showSignIn && (
-        <div
-          style={{
-            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.85)',
-            zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center',
-          }}
-          onClick={() => setShowSignIn(false)}
-        >
-          <div style={{ position: 'relative' }} onClick={e => e.stopPropagation()}>
-            <button
-              onClick={() => setShowSignIn(false)}
-              aria-label="Close sign-in"
-              style={{
-                position: 'absolute', top: -36, right: 0,
-                background: 'none', border: 'none', color: '#94a3b8',
-                cursor: 'pointer', fontSize: 13, fontFamily: 'inherit',
-              }}
-            >
-              ✕ Close
-            </button>
-            <p style={{
-              textAlign: 'center', fontSize: 12, color: '#94a3b8',
-              marginBottom: 12, fontFamily: "'JetBrains Mono', monospace",
-            }}>
-              Sign in to export your plan as PDF
-            </p>
-            <Authenticator
-              loginMechanisms={['email']}
-              components={{ Header: AuthHeader }}
-              services={authServices}
-              formFields={signInFormFields}
-            >
-              {() => <></>}
-            </Authenticator>
-          </div>
-        </div>
-      )}
+      <SignInModal open={showSignIn} onClose={closeSignIn} />
     </ThemeProvider>
   )
 }

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,13 +1,13 @@
-import { useEffect } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { Amplify } from 'aws-amplify'
-import { signUp, signOut as amplifySignOut } from 'aws-amplify/auth'
-import { Authenticator, ThemeProvider, useAuthenticator } from '@aws-amplify/ui-react'
+import { signUp, signOut as amplifySignOut, getCurrentUser } from 'aws-amplify/auth'
+import { Hub } from 'aws-amplify/utils'
+import { Authenticator, ThemeProvider } from '@aws-amplify/ui-react'
 import '@aws-amplify/ui-react/styles.css'
 import TrafficControlPlanner from './traffic-control-planner'
 import awsExports from './aws-exports'
 import { authTheme } from './auth/theme'
 import { AuthHeader } from './auth/AuthHeader'
-import { useAutoSignOut } from './auth/useAutoSignOut'
 import { identifyUser, resetAnalytics } from './analytics'
 
 Amplify.configure(awsExports)
@@ -28,48 +28,70 @@ const authServices = {
   },
 }
 
-function AuthedApp() {
-  const { signOut, user } = useAuthenticator((ctx) => [ctx.user])
-  useAutoSignOut(signOut)
-
-  const userId    = user?.username ?? null
-  const userEmail = user?.signInDetails?.loginId ?? null
-
-  // Re-identify whenever the signed-in user changes
-  useEffect(() => {
-    if (userId) identifyUser(userId, userEmail)
-  }, [userId, userEmail])
-
-  // Reset analytics only on unmount (sign-out / session end)
-  useEffect(() => {
-    return () => { resetAnalytics() }
-  }, [])
-
-  const handleSignOut = async () => {
-    try {
-      // global: true revokes the Cognito refresh token server-side so the
-      // user isn't auto-signed back in when they return to /app.
-      await amplifySignOut({ global: true })
-    } catch (err) {
-      // Log so server-side session failures are visible in monitoring.
-      console.error('[Auth] signOut error:', err)
-    } finally {
-      window.location.href = '/'
-    }
-  }
-
-  return (
-    <TrafficControlPlanner
-      userId={userId}
-      userEmail={userEmail}
-      onSignOut={handleSignOut}
-    />
-  )
+const signInFormFields = {
+  signUp: {
+    name: {
+      label: 'Full Name',
+      placeholder: 'Enter your full name',
+      isRequired: true,
+      order: 1,
+    },
+    email: { order: 2 },
+    password: { order: 3 },
+    confirm_password: { order: 4 },
+  },
 }
 
 export default function App() {
   // Evaluated at render time so test mocks can override the config object
   const AUTH_ENABLED = Boolean(awsExports.aws_user_pools_id && awsExports.aws_user_pools_web_client_id)
+
+  const [userId, setUserId]       = useState<string | null>(null)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
+  const [showSignIn, setShowSignIn] = useState(false)
+
+  useEffect(() => {
+    if (!AUTH_ENABLED) return
+
+    // Restore session if user is already signed in
+    getCurrentUser()
+      .then(u => {
+        const email = u.signInDetails?.loginId ?? null
+        setUserId(u.username)
+        setUserEmail(email)
+        identifyUser(u.username, email)
+      })
+      .catch(() => { /* not signed in — that's fine */ })
+
+    // React to auth events: sign-in, sign-out, token refresh failures
+    const unsubscribe = Hub.listen('auth', ({ payload }) => {
+      if (payload.event === 'signedIn') {
+        const u = payload.data as { username: string; signInDetails?: { loginId?: string } }
+        const email = u.signInDetails?.loginId ?? null
+        setUserId(u.username)
+        setUserEmail(email)
+        setShowSignIn(false)
+        identifyUser(u.username, email)
+      } else if (payload.event === 'signedOut') {
+        setUserId(null)
+        setUserEmail(null)
+        resetAnalytics()
+      } else if (payload.event === 'tokenRefresh_failure') {
+        handleSignOut()
+      }
+    })
+    return unsubscribe
+  }, [AUTH_ENABLED]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSignOut = useCallback(async () => {
+    try {
+      await amplifySignOut({ global: true })
+    } catch (err) {
+      console.error('[Auth] signOut error:', err)
+    } finally {
+      window.location.href = '/'
+    }
+  }, [])
 
   if (!AUTH_ENABLED) {
     return <TrafficControlPlanner userId={null} />
@@ -77,26 +99,50 @@ export default function App() {
 
   return (
     <ThemeProvider theme={authTheme} colorMode="dark">
-      <Authenticator
-        loginMechanisms={['email']}
-        components={{ Header: AuthHeader }}
-        services={authServices}
-        formFields={{
-          signUp: {
-            name: {
-              label: 'Full Name',
-              placeholder: 'Enter your full name',
-              isRequired: true,
-              order: 1,
-            },
-            email: { order: 2 },
-            password: { order: 3 },
-            confirm_password: { order: 4 },
-          },
-        }}
-      >
-        {() => <AuthedApp />}
-      </Authenticator>
+      <TrafficControlPlanner
+        userId={userId}
+        userEmail={userEmail}
+        onSignOut={userId ? handleSignOut : undefined}
+        onRequestSignIn={() => setShowSignIn(true)}
+      />
+
+      {showSignIn && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.85)',
+            zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+          onClick={() => setShowSignIn(false)}
+        >
+          <div style={{ position: 'relative' }} onClick={e => e.stopPropagation()}>
+            <button
+              onClick={() => setShowSignIn(false)}
+              aria-label="Close sign-in"
+              style={{
+                position: 'absolute', top: -36, right: 0,
+                background: 'none', border: 'none', color: '#94a3b8',
+                cursor: 'pointer', fontSize: 13, fontFamily: 'inherit',
+              }}
+            >
+              ✕ Close
+            </button>
+            <p style={{
+              textAlign: 'center', fontSize: 12, color: '#94a3b8',
+              marginBottom: 12, fontFamily: "'JetBrains Mono', monospace",
+            }}>
+              Sign in to export your plan as PDF
+            </p>
+            <Authenticator
+              loginMechanisms={['email']}
+              components={{ Header: AuthHeader }}
+              services={authServices}
+              formFields={signInFormFields}
+            >
+              {() => <></>}
+            </Authenticator>
+          </div>
+        </div>
+      )}
     </ThemeProvider>
   )
 }

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
   const { userId, userEmail, showSignIn, openSignIn, closeSignIn, handleSignOut } = useAuthSession(AUTH_ENABLED)
 
   if (!AUTH_ENABLED) {
-    return <TrafficControlPlanner userId={null} />
+    return <TrafficControlPlanner userId={null} userEmail={null} />
   }
 
   return (

--- a/my-app/src/auth/SignInModal.tsx
+++ b/my-app/src/auth/SignInModal.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react'
+import { signUp } from 'aws-amplify/auth'
+import { Authenticator } from '@aws-amplify/ui-react'
+import { AuthHeader } from './AuthHeader'
+
+const authServices = {
+  async handleSignUp(input: Parameters<typeof signUp>[0]) {
+    const attrs = (input.options?.userAttributes ?? {}) as Record<string, string>
+    const name = attrs['name'] ?? ''
+    return signUp({
+      ...input,
+      options: { ...input.options, userAttributes: { ...attrs, name } },
+    })
+  },
+}
+
+const formFields = {
+  signUp: {
+    name:             { label: 'Full Name', placeholder: 'Enter your full name', isRequired: true, order: 1 },
+    email:            { order: 2 },
+    password:         { order: 3 },
+    confirm_password: { order: 4 },
+  },
+}
+
+interface SignInModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function SignInModal({ open, onClose }: SignInModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Focus the dialog on open
+  useEffect(() => {
+    if (open) dialogRef.current?.focus()
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="presentation"
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.85)',
+        zIndex: 2000, display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={onClose}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Sign in to export your plan as PDF"
+        tabIndex={-1}
+        style={{ position: 'relative', outline: 'none' }}
+        onClick={e => e.stopPropagation()}
+        onKeyDown={e => { if (e.key === 'Escape') onClose() }}
+      >
+        <button
+          onClick={onClose}
+          aria-label="Close sign-in"
+          style={{
+            position: 'absolute', top: -36, right: 0,
+            background: 'none', border: 'none', color: '#94a3b8',
+            cursor: 'pointer', fontSize: 13, fontFamily: 'inherit',
+          }}
+        >
+          ✕ Close
+        </button>
+        <p style={{
+          textAlign: 'center', fontSize: 12, color: '#94a3b8',
+          marginBottom: 12, fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          Sign in to export your plan as PDF
+        </p>
+        <Authenticator
+          loginMechanisms={['email']}
+          components={{ Header: AuthHeader }}
+          services={authServices}
+          formFields={formFields}
+        >
+          {() => <></>}
+        </Authenticator>
+      </div>
+    </div>
+  )
+}

--- a/my-app/src/auth/useAuthSession.ts
+++ b/my-app/src/auth/useAuthSession.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState, useCallback } from 'react'
+import { getCurrentUser, signOut as amplifySignOut } from 'aws-amplify/auth'
+import { Hub } from 'aws-amplify/utils'
+import { identifyUser, resetAnalytics } from '../analytics'
+
+export interface AuthSession {
+  userId: string | null
+  userEmail: string | null
+  showSignIn: boolean
+  openSignIn: () => void
+  closeSignIn: () => void
+  handleSignOut: () => Promise<void>
+}
+
+export function useAuthSession(authEnabled: boolean): AuthSession {
+  const [userId, setUserId]       = useState<string | null>(null)
+  const [userEmail, setUserEmail] = useState<string | null>(null)
+  const [showSignIn, setShowSignIn] = useState(false)
+
+  const handleSignOut = useCallback(async () => {
+    try {
+      await amplifySignOut({ global: true })
+    } catch (err) {
+      console.error('[Auth] signOut error:', err)
+    }
+    // Stay on the current page — Hub signedOut event clears userId/userEmail
+  }, [])
+
+  useEffect(() => {
+    if (!authEnabled) return
+
+    getCurrentUser()
+      .then(u => {
+        const email = u.signInDetails?.loginId ?? null
+        setUserId(u.username)
+        setUserEmail(email)
+        identifyUser(u.username, email)
+      })
+      .catch(() => { /* not signed in — that's fine */ })
+
+    const unsubscribe = Hub.listen('auth', ({ payload }) => {
+      if (payload.event === 'signedIn') {
+        const u = payload.data as { username: string; signInDetails?: { loginId?: string } }
+        const email = u.signInDetails?.loginId ?? null
+        setUserId(u.username)
+        setUserEmail(email)
+        setShowSignIn(false)
+        identifyUser(u.username, email)
+      } else if (payload.event === 'signedOut') {
+        setUserId(null)
+        setUserEmail(null)
+        resetAnalytics()
+      } else if (payload.event === 'tokenRefresh_failure') {
+        handleSignOut()
+      }
+    })
+
+    return unsubscribe
+  }, [authEnabled, handleSignOut])
+
+  return {
+    userId,
+    userEmail,
+    showSignIn,
+    openSignIn:  () => setShowSignIn(true),
+    closeSignIn: () => setShowSignIn(false),
+    handleSignOut,
+  }
+}

--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -546,6 +546,29 @@ describe('Auth props', () => {
     expect(signOutIdx).toBeGreaterThan(pngIdx)
     expect(signOutIdx).toBeGreaterThan(pdfIdx)
   })
+
+  it('clicking Export PDF when anonymous calls onRequestSignIn instead of opening the preview', async () => {
+    const onRequestSignIn = vi.fn()
+    const user = userEvent.setup()
+    render(<TrafficControlPlanner userId={null} onRequestSignIn={onRequestSignIn} />)
+    await user.click(screen.getByTestId('export-pdf-button'))
+    expect(onRequestSignIn).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('export-preview-modal')).not.toBeInTheDocument()
+  })
+
+  it('clicking Export PDF when signed in does NOT call onRequestSignIn', async () => {
+    const onRequestSignIn = vi.fn()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(new Blob(['%PDF'], { type: 'application/pdf' })),
+    }))
+    const user = userEvent.setup()
+    render(<TrafficControlPlanner userId="user-abc" onRequestSignIn={onRequestSignIn} />)
+    await user.click(screen.getByTestId('export-pdf-button'))
+    expect(onRequestSignIn).not.toHaveBeenCalled()
+    expect(await screen.findByTestId('export-preview-modal')).toBeInTheDocument()
+    vi.unstubAllGlobals()
+  })
 })
 
 // ─── Pre-beta banner ──────────────────────────────────────────────────────────

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -2197,6 +2197,7 @@ interface PlannerProps {
   userId?: string | null;
   userEmail?: string | null;
   onSignOut?: () => void;
+  onRequestSignIn?: () => void;
 }
 
 const CLOUD_ENABLED = Boolean(import.meta.env.VITE_S3_BUCKET && import.meta.env.VITE_COGNITO_IDENTITY_POOL_ID);
@@ -2204,7 +2205,7 @@ const CONTACT_EMAIL = (import.meta.env.VITE_CONTACT_EMAIL as string | undefined)
 const BANNER_KEY = 'tcp_prebeta_banner_dismissed';
 const PDF_SEEN_KEY = 'tcp_pdf_export_seen';
 
-export default function TrafficControlPlanner({ userId = null, userEmail = null, onSignOut }: PlannerProps = {}) {
+export default function TrafficControlPlanner({ userId = null, userEmail = null, onSignOut, onRequestSignIn }: PlannerProps = {}) {
   const stageRef = useRef<Konva.Stage>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const sessionStartRef = useRef<number>(Date.now());
@@ -3060,6 +3061,10 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   };
 
   const exportPDF = () => {
+    if (!userId && onRequestSignIn) {
+      onRequestSignIn();
+      return;
+    }
     const stage = stageRef.current;
     if (!stage) return;
     const canvas = stage.toCanvas({ pixelRatio: 2 });


### PR DESCRIPTION
## Summary

Closes #184

- Anonymous users can now access the full canvas freely — no sign-in required to draw roads, place signs, or experiment
- Sign-in is only triggered when the user clicks **Export PDF** without being authenticated
- A modal with the Cognito sign-in/sign-up form appears at that moment; once signed in, the user can proceed directly to export

## How it works

- `App.tsx` no longer wraps the app in `<Authenticator>`. Instead it uses `getCurrentUser()` on mount to restore existing sessions, and Amplify Hub to react to `signedIn` / `signedOut` / `tokenRefresh_failure` events
- `TrafficControlPlanner` receives a new `onRequestSignIn` prop; `exportPDF()` calls it instead of opening the export preview when the user is anonymous
- The sign-in modal is a simple overlay rendered in `App.tsx`, dismissed on backdrop click or the ✕ button

## Test plan

- [ ] Open the app without signing in — canvas is fully accessible
- [ ] Place signs, apply a template — all works anonymously
- [ ] Click Export PDF without being signed in — sign-in modal appears with message "Sign in to export your plan as PDF"
- [ ] Sign in via the modal — modal closes, click Export PDF again — export preview appears and PDF downloads
- [ ] Reload while signed in — session is restored, Export PDF goes straight to preview (no modal)
- [ ] Sign out — returns to anonymous mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delay authentication requirement until PDF export and introduce a sign-in modal triggered from the planner instead of gating the entire app.

New Features:
- Allow anonymous users to access and use the canvas without signing in.
- Trigger a sign-in modal when an unauthenticated user attempts to export a plan as PDF.

Enhancements:
- Move session restoration and auth event handling into the app shell using getCurrentUser and Amplify Hub.
- Pass user identity and optional auth callbacks into the planner component instead of wrapping the app with the Authenticator.

Tests:
- Expand App tests to cover session restoration, auth event handling, and the new sign-in modal trigger from the planner.