### PR TITLE
feat(toolbar): replace email addresses with user icon + Sign Out

### DIFF
--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -516,9 +516,19 @@ describe('Auth props', () => {
     expect(screen.getByTestId('sign-out-button').title).toBe('alice@example.com')
   })
 
+  it('sign-out button does not expose email in visible text', () => {
+    render(<TrafficControlPlanner userId="cognito-uuid" userEmail="alice@example.com" onSignOut={vi.fn()} />)
+    expect(screen.getByTestId('sign-out-button').textContent).not.toContain('alice@example.com')
+  })
+
   it('sign-out button title falls back to userId when no email provided', () => {
     render(<TrafficControlPlanner userId="cognito-uuid" onSignOut={vi.fn()} />)
     expect(screen.getByTestId('sign-out-button').title).toBe('cognito-uuid')
+  })
+
+  it('sign-out button title shows "Signed in" when neither userId nor userEmail provided', () => {
+    render(<TrafficControlPlanner onSignOut={vi.fn()} />)
+    expect(screen.getByTestId('sign-out-button').title).toBe('Signed in')
   })
 
   it('clicking sign-out button calls onSignOut', async () => {

--- a/my-app/src/test/planner.test.tsx
+++ b/my-app/src/test/planner.test.tsx
@@ -511,22 +511,14 @@ describe('Auth props', () => {
     expect(screen.getByTestId('sign-out-button')).toBeInTheDocument()
   })
 
-  it('user-identity label shows the userId when no email is provided', () => {
-    render(<TrafficControlPlanner userId="alice@example.com" onSignOut={vi.fn()} />)
-    expect(screen.getByTestId('user-identity').textContent).toContain('alice@example.com')
-  })
-
-  it('user-identity label prefers userEmail over userId', () => {
+  it('sign-out button title shows userEmail when provided', () => {
     render(<TrafficControlPlanner userId="cognito-uuid" userEmail="alice@example.com" onSignOut={vi.fn()} />)
-    const el = screen.getByTestId('user-identity')
-    expect(el.textContent).toContain('alice@example.com')
-    expect(el.textContent).not.toContain('cognito-uuid')
-    expect(el.title).toBe('alice@example.com')
+    expect(screen.getByTestId('sign-out-button').title).toBe('alice@example.com')
   })
 
-  it('user-identity label is not rendered when neither userId nor userEmail is provided', () => {
-    render(<TrafficControlPlanner onSignOut={vi.fn()} />)
-    expect(screen.queryByTestId('user-identity')).not.toBeInTheDocument()
+  it('sign-out button title falls back to userId when no email provided', () => {
+    render(<TrafficControlPlanner userId="cognito-uuid" onSignOut={vi.fn()} />)
+    expect(screen.getByTestId('sign-out-button').title).toBe('cognito-uuid')
   })
 
   it('clicking sign-out button calls onSignOut', async () => {
@@ -593,11 +585,9 @@ describe('Pre-beta banner', () => {
     expect(screen.queryByTestId('prebeta-banner')).not.toBeInTheDocument()
   })
 
-  it('contact email link is present in the toolbar', () => {
+  it('contact email link is not shown in the toolbar', () => {
     render(<TrafficControlPlanner />)
-    const link = screen.getByTestId('contact-email')
-    expect(link).toBeInTheDocument()
-    expect(link.getAttribute('href')).toMatch(/^mailto:/)
+    expect(screen.queryByTestId('contact-email')).not.toBeInTheDocument()
   })
 })
 

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -3250,15 +3250,15 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
             const qs = params.toString();
             window.open(`/feedback.html${qs ? `?${qs}` : ''}`, '_blank', 'noopener,noreferrer');
           }} style={panelBtnStyle(false)} title="Report an issue or submit feedback">Report Issue</button>
-          <a href={`mailto:${CONTACT_EMAIL}`} data-testid="contact-email" style={{ fontSize: 10, color: COLORS.textDim, textDecoration: "none", whiteSpace: "nowrap", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", flexShrink: 1 }} title="Email support">{CONTACT_EMAIL}</a>
-          {onSignOut && (<>
-            {(userEmail || userId) && (
-              <span data-testid="user-identity" style={{ fontSize: 10, color: COLORS.textMuted, maxWidth: 160, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={userEmail ?? userId ?? ''}>
-                {userEmail ?? userId}
-              </span>
-            )}
-            <button onClick={onSignOut} data-testid="sign-out-button" style={panelBtnStyle(false)}>Sign Out</button>
-          </>)}
+          {onSignOut && (
+            <button onClick={onSignOut} data-testid="sign-out-button" style={{ ...panelBtnStyle(false), display: "flex", alignItems: "center", gap: 5 }} title={userEmail ?? userId ?? 'Signed in'}>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+                <circle cx="12" cy="7" r="4"/>
+              </svg>
+              Sign Out
+            </button>
+          )}
         </div>
 
         <div style={{ position: "relative", flex: "0 1 300px" }}>


### PR DESCRIPTION
## Summary

Closes the toolbar email cleanup item from the session handoff.

- Removes the `jfisher@fisherconsulting.org` contact email link from the toolbar
- Removes the `user-identity` span that was showing the Cognito login email (`jfisher94002@GMAIL.COM`)
- Signed-in users now see a single **person icon + Sign Out** button; the tooltip shows their email (or userId as fallback) so the identity is still visible on hover
- Anonymous users see no user controls — sign-in is gated at PDF export (PR #185)

## Test plan

- [ ] Sign in — toolbar shows person icon + "Sign Out", no email text visible
- [ ] Hover the Sign Out button — tooltip shows the signed-in email
- [ ] Sign out — user controls disappear, canvas remains usable
- [ ] Anonymous session — no email addresses anywhere in the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace toolbar email-based identity display with an icon-based Sign Out control and remove the support contact email link from the toolbar.

New Features:
- Show a person icon alongside the Sign Out button for authenticated users, with a tooltip exposing their email or userId as identity.

Enhancements:
- Simplify authenticated toolbar controls to a single Sign Out button with identity moved into the button tooltip.
- Remove the static contact support email link from the toolbar UI.

Tests:
- Update auth-related tests to validate identity information via the Sign Out button tooltip instead of a user-identity label.
- Update pre-beta banner tests to assert that the contact email link is no longer rendered in the toolbar.