### PR TITLE
fix(e2e): update auth tests for modal-based sign-in flow

### DIFF
--- a/my-app/src/e2e/auth.setup.ts
+++ b/my-app/src/e2e/auth.setup.ts
@@ -16,14 +16,19 @@ setup('sign in as E2E test user', async ({ page }) => {
 
   await page.goto('/app')
 
-  // Wait for the Amplify Authenticator to mount
+  // Canvas loads immediately — no sign-in gate at app entry.
+  // Trigger the sign-in modal via the Export PDF button.
+  await expect(page.getByTestId('export-pdf-button')).toBeVisible({ timeout: 15_000 })
+  await page.getByTestId('export-pdf-button').click()
+
+  // Wait for the sign-in modal
   await expect(page.getByRole('tab', { name: 'Sign In' })).toBeVisible({ timeout: 15_000 })
 
   await page.getByLabel('Email').fill(email)
   await page.getByRole('textbox', { name: 'Password' }).fill(password)
   await page.getByRole('button', { name: 'Sign in' }).click()
 
-  // Wait until the app canvas is visible — confirms successful sign-in
+  // Modal closes on success — canvas-container confirms we're in
   await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
 
   await page.context().storageState({ path: AUTH_FILE })

--- a/my-app/src/e2e/auth.setup.ts
+++ b/my-app/src/e2e/auth.setup.ts
@@ -3,9 +3,10 @@
  * Signs in with the E2E test account and saves browser state so all
  * other tests start already authenticated.
  */
-import { test as setup, expect } from '@playwright/test'
+import { test as setup } from '@playwright/test'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { expectSignedIn, openSignInModal } from './openSignInModal'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const AUTH_FILE = path.join(__dirname, '.auth/user.json')
@@ -14,22 +15,13 @@ setup('sign in as E2E test user', async ({ page }) => {
   const email    = process.env.E2E_TEST_EMAIL    ?? 'e2e-test@tcplanpro.com'
   const password = process.env.E2E_TEST_PASSWORD ?? 'E2eTestPass2026!'
 
-  await page.goto('/app')
-
-  // Canvas loads immediately — no sign-in gate at app entry.
-  // Trigger the sign-in modal via the Export PDF button.
-  await expect(page.getByTestId('export-pdf-button')).toBeVisible({ timeout: 15_000 })
-  await page.getByTestId('export-pdf-button').click()
-
-  // Wait for the sign-in modal
-  await expect(page.getByRole('tab', { name: 'Sign In' })).toBeVisible({ timeout: 15_000 })
+  await openSignInModal(page)
 
   await page.getByLabel('Email').fill(email)
   await page.getByRole('textbox', { name: 'Password' }).fill(password)
   await page.getByRole('button', { name: 'Sign in' }).click()
 
-  // Modal closes on success — canvas-container confirms we're in
-  await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
+  await expectSignedIn(page)
 
   await page.context().storageState({ path: AUTH_FILE })
 })

--- a/my-app/src/e2e/auth.spec.ts
+++ b/my-app/src/e2e/auth.spec.ts
@@ -5,17 +5,10 @@
 import { test, expect } from '@playwright/test'
 import { writeFileSync } from 'fs'
 import { join } from 'path'
+import { expectSignedIn, openSignInModal } from './openSignInModal'
 
 const E2E_EMAIL    = process.env.E2E_TEST_EMAIL    ?? 'e2e-test@tcplanpro.com'
 const E2E_PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'E2eTestPass2026!'
-
-/** Opens the sign-in modal by clicking Export PDF. */
-async function openSignInModal(page: Parameters<Parameters<typeof test>[1]>[0]) {
-  await page.goto('/app')
-  await expect(page.getByTestId('export-pdf-button')).toBeVisible({ timeout: 15_000 })
-  await page.getByTestId('export-pdf-button').click()
-  await expect(page.getByRole('tab', { name: 'Sign In' })).toBeVisible({ timeout: 15_000 })
-}
 
 test.describe('Sign In', () => {
   test.beforeEach(async ({ page }) => {
@@ -26,8 +19,7 @@ test.describe('Sign In', () => {
     await page.getByLabel('Email').fill(E2E_EMAIL)
     await page.getByRole('textbox', { name: 'Password' }).fill(E2E_PASSWORD)
     await page.getByRole('button', { name: 'Sign in' }).click()
-    // Modal closes; canvas is already visible underneath
-    await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
+    await expectSignedIn(page)
   })
 
   test('shows error with wrong password', async ({ page }) => {
@@ -93,11 +85,11 @@ test.describe('Sign Out', () => {
     await page.getByLabel('Email').fill(E2E_EMAIL)
     await page.getByRole('textbox', { name: 'Password' }).fill(E2E_PASSWORD)
     await page.getByRole('button', { name: 'Sign in' }).click()
-    await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
+    await expectSignedIn(page)
 
     // Sign out — stays on /app, sign-out button disappears
     await page.getByTestId('sign-out-button').click()
-    await expect(page).toHaveURL(/\/app/)
+    await expect(page).toHaveURL((url: URL) => url.pathname === '/app')
     await expect(page.getByTestId('sign-out-button')).not.toBeVisible()
   })
 })

--- a/my-app/src/e2e/auth.spec.ts
+++ b/my-app/src/e2e/auth.spec.ts
@@ -9,16 +9,24 @@ import { join } from 'path'
 const E2E_EMAIL    = process.env.E2E_TEST_EMAIL    ?? 'e2e-test@tcplanpro.com'
 const E2E_PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'E2eTestPass2026!'
 
+/** Opens the sign-in modal by clicking Export PDF. */
+async function openSignInModal(page: Parameters<Parameters<typeof test>[1]>[0]) {
+  await page.goto('/app')
+  await expect(page.getByTestId('export-pdf-button')).toBeVisible({ timeout: 15_000 })
+  await page.getByTestId('export-pdf-button').click()
+  await expect(page.getByRole('tab', { name: 'Sign In' })).toBeVisible({ timeout: 15_000 })
+}
+
 test.describe('Sign In', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/app')
-    await expect(page.getByRole('tab', { name: 'Sign In' })).toBeVisible({ timeout: 15_000 })
+    await openSignInModal(page)
   })
 
   test('signs in with valid credentials and lands on app', async ({ page }) => {
     await page.getByLabel('Email').fill(E2E_EMAIL)
     await page.getByRole('textbox', { name: 'Password' }).fill(E2E_PASSWORD)
     await page.getByRole('button', { name: 'Sign in' }).click()
+    // Modal closes; canvas is already visible underneath
     await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
   })
 
@@ -32,7 +40,7 @@ test.describe('Sign In', () => {
 
 test.describe('Create Account', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/app')
+    await openSignInModal(page)
     await page.getByRole('tab', { name: 'Create Account' }).click()
     await expect(page.getByRole('button', { name: 'Create Account' })).toBeVisible({ timeout: 15_000 })
   })
@@ -79,16 +87,17 @@ test.describe('Create Account', () => {
 })
 
 test.describe('Sign Out', () => {
-  test('sign out redirects to landing page', async ({ page }) => {
-    // Sign in first
-    await page.goto('/app')
+  test('sign out returns to anonymous canvas — no redirect', async ({ page }) => {
+    // Sign in via modal
+    await openSignInModal(page)
     await page.getByLabel('Email').fill(E2E_EMAIL)
     await page.getByRole('textbox', { name: 'Password' }).fill(E2E_PASSWORD)
     await page.getByRole('button', { name: 'Sign in' }).click()
     await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
 
-    // Sign out
+    // Sign out — stays on /app, sign-out button disappears
     await page.getByTestId('sign-out-button').click()
-    await expect(page).toHaveURL('/')
+    await expect(page).toHaveURL(/\/app/)
+    await expect(page.getByTestId('sign-out-button')).not.toBeVisible()
   })
 })

--- a/my-app/src/e2e/beta-tools.spec.ts
+++ b/my-app/src/e2e/beta-tools.spec.ts
@@ -3,15 +3,12 @@
  * Runs against staging with stored auth state.
  */
 import { test, expect } from '@playwright/test'
+import { seedMapCenter } from './openSignInModal'
 
 test.beforeEach(async ({ page }) => {
   // Pre-seed a mapCenter so tools that require a map (lane_mask, crosswalk,
   // turn_lane) activate directly instead of showing the address-required modal.
-  await page.addInitScript(() => {
-    const autosave = JSON.parse(localStorage.getItem('tcp_autosave') || '{}')
-    autosave.mapCenter = { lat: 37.77, lon: -122.41, zoom: 16 }
-    localStorage.setItem('tcp_autosave', JSON.stringify(autosave))
-  })
+  await seedMapCenter(page)
   await page.goto('/app')
   await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
 })

--- a/my-app/src/e2e/beta-tools.spec.ts
+++ b/my-app/src/e2e/beta-tools.spec.ts
@@ -5,6 +5,13 @@
 import { test, expect } from '@playwright/test'
 
 test.beforeEach(async ({ page }) => {
+  // Pre-seed a mapCenter so tools that require a map (lane_mask, crosswalk,
+  // turn_lane) activate directly instead of showing the address-required modal.
+  await page.addInitScript(() => {
+    const autosave = JSON.parse(localStorage.getItem('tcp_autosave') || '{}')
+    autosave.mapCenter = { lat: 37.77, lon: -122.41, zoom: 16 }
+    localStorage.setItem('tcp_autosave', JSON.stringify(autosave))
+  })
   await page.goto('/app')
   await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
 })

--- a/my-app/src/e2e/canvas.spec.ts
+++ b/my-app/src/e2e/canvas.spec.ts
@@ -3,8 +3,12 @@
  * All tests run with stored auth state from auth.setup.ts.
  */
 import { test, expect } from '@playwright/test'
+import { seedMapCenter } from './openSignInModal'
 
 test.beforeEach(async ({ page }) => {
+  // Pre-seed a mapCenter so tools that require a map activate directly
+  // instead of showing the address-required modal.
+  await seedMapCenter(page)
   await page.goto('/app')
   await expect(page.getByTestId('canvas-container')).toBeVisible({ timeout: 20_000 })
 })

--- a/my-app/src/e2e/openSignInModal.ts
+++ b/my-app/src/e2e/openSignInModal.ts
@@ -1,5 +1,18 @@
 import { expect, type Page } from '@playwright/test'
 
+/**
+ * Seeds a mapCenter into tcp_autosave localStorage before page load so that
+ * tools in TOOLS_REQUIRING_MAP activate directly without showing the
+ * address-required modal. Call via page.addInitScript() before page.goto().
+ */
+export function seedMapCenter(page: Page): Promise<void> {
+  return page.addInitScript(() => {
+    const autosave = JSON.parse(localStorage.getItem('tcp_autosave') || '{}')
+    autosave.mapCenter = { lat: 37.77, lon: -122.41, zoom: 16 }
+    localStorage.setItem('tcp_autosave', JSON.stringify(autosave))
+  })
+}
+
 /** Opens the sign-in modal by clicking Export PDF on /app. */
 export async function openSignInModal(page: Page) {
   await page.goto('/app')

--- a/my-app/src/e2e/openSignInModal.ts
+++ b/my-app/src/e2e/openSignInModal.ts
@@ -1,0 +1,15 @@
+import { expect, type Page } from '@playwright/test'
+
+/** Opens the sign-in modal by clicking Export PDF on /app. */
+export async function openSignInModal(page: Page) {
+  await page.goto('/app')
+  await expect(page.getByTestId('export-pdf-button')).toBeVisible({ timeout: 15_000 })
+  await page.getByTestId('export-pdf-button').click()
+  await expect(page.getByRole('tab', { name: 'Sign In' })).toBeVisible({ timeout: 15_000 })
+}
+
+/** After a successful sign-in, the modal must close and authenticated UI must appear (canvas is visible for anonymous users too). */
+export async function expectSignedIn(page: Page) {
+  await expect(page.getByRole('tab', { name: 'Sign In' })).toBeHidden({ timeout: 20_000 })
+  await expect(page.getByTestId('sign-out-button')).toBeVisible({ timeout: 20_000 })
+}


### PR DESCRIPTION
## Summary
- Fixes E2E auth tests broken since PR #185 moved the sign-in gate from app entry to the PDF export button
- All tests now open the sign-in modal by clicking the `export-pdf-button` instead of expecting the Amplify Authenticator at page load
- Extracted `openSignInModal()` helper to avoid repetition across Sign In, Create Account, and Sign Out describes
- Updated Sign Out test: now asserts the page stays on `/app` and the sign-out button disappears, rather than asserting a redirect to `/`

## Test plan
- [ ] E2E auth setup (`auth.setup.ts`) signs in successfully via modal
- [ ] Sign In — valid credentials closes modal and shows canvas
- [ ] Sign In — wrong password shows alert inside modal
- [ ] Create Account — validation errors still surface correctly
- [ ] Sign Out — stays on `/app`, sign-out button disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update E2E authentication tests to align with the new modal-based sign-in flow triggered from the app canvas.

Bug Fixes:
- Adjust sign-in, create-account, and sign-out E2E flows to open the sign-in modal via the Export PDF button instead of expecting an auth gate on initial app load.
- Correct the sign-out E2E assertion to expect staying on the /app route with the sign-out button hidden rather than redirecting to the landing page.

Enhancements:
- Introduce a shared openSignInModal helper to reduce duplication across authentication-related E2E tests.