### PR TITLE
fix(canvas): unique React keys for road markings, shoulders, sidewalks, and bezier tangents

### DIFF
--- a/my-app/src/components/tcp/canvas/DrawingOverlays.tsx
+++ b/my-app/src/components/tcp/canvas/DrawingOverlays.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import { Line, Rect, Circle } from 'react-konva';
 import type { DrawStart, Point, LaneMaskObject, CrosswalkObject } from '../../../types';
 import { sampleBezier, sampleCubicBezier } from '../../../utils';
@@ -17,7 +18,7 @@ interface DrawingOverlaysProps {
 
 export function DrawingOverlays({ tool, roadDrawMode, drawStart, cursorPos, snapIndicator, polyPoints, curvePoints, cubicPoints }: DrawingOverlaysProps) {
   const previewTarget = snapIndicator || cursorPos;
-  const elements = [];
+  const elements: React.ReactNode[] = [];
 
   if (drawStart && tool === "road" && roadDrawMode === "straight") {
     elements.push(
@@ -129,7 +130,7 @@ export function DrawingOverlays({ tool, roadDrawMode, drawStart, cursorPos, snap
           stroke="rgba(245,158,11,0.65)" strokeWidth={2} dash={[6, 4]} tension={0} listening={false} />
       );
       elements.push(
-        <Line key="cubic-tangent-1"
+        <Line key="cubic-tangent-1-2pt"
           points={[q0.x, q0.y, q1.x, q1.y]}
           stroke="rgba(255,255,255,0.2)" strokeWidth={1} dash={[3, 3]} listening={false} />
       );
@@ -140,12 +141,12 @@ export function DrawingOverlays({ tool, roadDrawMode, drawStart, cursorPos, snap
           stroke="rgba(245,158,11,0.65)" strokeWidth={2} dash={[6, 4]} tension={0} listening={false} />
       );
       elements.push(
-        <Line key="cubic-tangent-1"
+        <Line key="cubic-tangent-1-3pt"
           points={[q0.x, q0.y, q1.x, q1.y]}
           stroke="rgba(255,255,255,0.2)" strokeWidth={1} dash={[3, 3]} listening={false} />
       );
       elements.push(
-        <Line key="cubic-tangent-2"
+        <Line key="cubic-tangent-2-3pt"
           points={[q2.x, q2.y, previewTarget.x, previewTarget.y]}
           stroke="rgba(255,255,255,0.2)" strokeWidth={1} dash={[3, 3]} listening={false} />
       );

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -74,12 +74,13 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
     }
   }
 
+  const { id } = obj;
   const shoulderLines = shoulderWidth > 0 ? [
-    <Line key="sl" points={[
+    <Line key={`${id}-sl`} points={[
       x1 + nx * (hw + shoulderWidth / 2), y1 + ny * (hw + shoulderWidth / 2),
       x2 + nx * (hw + shoulderWidth / 2), y2 + ny * (hw + shoulderWidth / 2),
     ]} stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} listening={false} />,
-    <Line key="sr" points={[
+    <Line key={`${id}-sr`} points={[
       x1 - nx * (hw + shoulderWidth / 2), y1 - ny * (hw + shoulderWidth / 2),
       x2 - nx * (hw + shoulderWidth / 2), y2 - ny * (hw + shoulderWidth / 2),
     ]} stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} listening={false} />,
@@ -90,11 +91,11 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
   if (sidewalkWidth > 0 && sidewalkSide) {
     if (showLeft) {
       sidewalkLines.push(
-        <Line key="swl-fill" points={[
+        <Line key={`${id}-swl-fill`} points={[
           x1 + nx * swOff, y1 + ny * swOff,
           x2 + nx * swOff, y2 + ny * swOff,
         ]} stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} listening={false} />,
-        <Line key="swl-edge" points={[
+        <Line key={`${id}-swl-edge`} points={[
           x1 + nx * (swOff + sidewalkWidth / 2), y1 + ny * (swOff + sidewalkWidth / 2),
           x2 + nx * (swOff + sidewalkWidth / 2), y2 + ny * (swOff + sidewalkWidth / 2),
         ]} stroke="rgba(160,155,145,0.8)" strokeWidth={1} listening={false} />,
@@ -102,11 +103,11 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
     }
     if (showRight) {
       sidewalkLines.push(
-        <Line key="swr-fill" points={[
+        <Line key={`${id}-swr-fill`} points={[
           x1 - nx * swOff, y1 - ny * swOff,
           x2 - nx * swOff, y2 - ny * swOff,
         ]} stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} listening={false} />,
-        <Line key="swr-edge" points={[
+        <Line key={`${id}-swr-edge`} points={[
           x1 - nx * (swOff + sidewalkWidth / 2), y1 - ny * (swOff + sidewalkWidth / 2),
           x2 - nx * (swOff + sidewalkWidth / 2), y2 - ny * (swOff + sidewalkWidth / 2),
         ]} stroke="rgba(160,155,145,0.8)" strokeWidth={1} listening={false} />,
@@ -133,7 +134,7 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
 
 interface PolylineRoadProps { obj: PolylineRoadObject; isSelected: boolean; }
 export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
-  const { points, width, lanes, roadType, smooth } = obj;
+  const { id, points, width, lanes, roadType, smooth } = obj;
   const tension = smooth ? 0.5 : 0;
   if (!points || points.length < 2) return null;
 
@@ -159,14 +160,14 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
       if (isCenter) {
         for (const d of [-2, 2]) {
           laneMarkings.push(
-            <Line key={`c${li}_${si}_${d}`}
+            <Line key={`${id}-c${li}_${si}_${d}`}
               points={[x1 + cx * (off + d), y1 + cy * (off + d), x2 + cx * (off + d), y2 + cy * (off + d)]}
               stroke={COLORS.roadLine} strokeWidth={2} listening={false} />
           );
         }
       } else {
         laneMarkings.push(
-          <Line key={`l${li}_${si}`}
+          <Line key={`${id}-l${li}_${si}`}
             points={[x1 + cx * off, y1 + cy * off, x2 + cx * off, y2 + cy * off]}
             stroke={COLORS.laneMarking} strokeWidth={1.5} dash={[12, 18]} listening={false} />
         );
@@ -192,7 +193,7 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
 
 interface CurveRoadProps { obj: CurveRoadObject; isSelected: boolean; }
 export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
-  const { points, width, lanes, roadType } = obj;
+  const { id, points, width, lanes, roadType } = obj;
   if (!points || points.length < 3) return null;
   const [p0, p1, p2] = points;
 
@@ -212,14 +213,14 @@ export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
       if (isCenter) {
         for (const d of [-2, 2]) {
           laneMarkings.push(
-            <Line key={`c${li}_${si}_${d}`}
+            <Line key={`${id}-c${li}_${si}_${d}`}
               points={[x1 + cx * (off + d), y1 + cy * (off + d), x2 + cx * (off + d), y2 + cy * (off + d)]}
               stroke={COLORS.roadLine} strokeWidth={2} listening={false} />
           );
         }
       } else {
         laneMarkings.push(
-          <Line key={`l${li}_${si}`}
+          <Line key={`${id}-l${li}_${si}`}
             points={[x1 + cx * off, y1 + cy * off, x2 + cx * off, y2 + cy * off]}
             stroke={COLORS.laneMarking} strokeWidth={1.5} dash={[12, 18]} listening={false} />
         );
@@ -246,7 +247,7 @@ export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
 
 interface CubicBezierRoadProps { obj: CubicBezierRoadObject; isSelected: boolean; }
 export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
-  const { points, width, lanes, roadType } = obj;
+  const { id, points, width, lanes, roadType } = obj;
   if (!points || points.length < 4) return null;
   const [p0, p1, p2, p3] = points;
 
@@ -266,14 +267,14 @@ export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
       if (isCenter) {
         for (const d of [-2, 2]) {
           laneMarkings.push(
-            <Line key={`c${li}_${si}_${d}`}
+            <Line key={`${id}-c${li}_${si}_${d}`}
               points={[x1 + cx * (off + d), y1 + cy * (off + d), x2 + cx * (off + d), y2 + cy * (off + d)]}
               stroke={COLORS.roadLine} strokeWidth={2} listening={false} />
           );
         }
       } else {
         laneMarkings.push(
-          <Line key={`l${li}_${si}`}
+          <Line key={`${id}-l${li}_${si}`}
             points={[x1 + cx * off, y1 + cy * off, x2 + cx * off, y2 + cy * off]}
             stroke={COLORS.laneMarking} strokeWidth={1.5} dash={[12, 18]} listening={false} />
         );


### PR DESCRIPTION
## Summary

- Fixes duplicate/non-unique React `key` props across canvas shape components, preventing reconciliation warnings and potential rendering bugs.
- Types `elements` array in `DrawingOverlays` as `React.ReactNode[]` to eliminate implicit `any[]`.

## Changes

| Issue | Fix |
|-------|-----|
| #235 | `DrawingOverlays`: `elements` typed as `React.ReactNode[]` |
| #234 | `DrawingOverlays`: cubic bezier tangent keys disambiguated by point count (`-2pt` / `-3pt` suffix) |
| #236 | `ObjectShapes/RoadSegment`: shoulder and sidewalk keys prefixed with `obj.id` |
| #237 | `ObjectShapes/PolylineRoad`, `CurveRoad`, `CubicBezierRoad`: lane marking keys prefixed with `obj.id` |

## Test plan

- [ ] TypeScript: `tsc --noEmit` passes
- [ ] Unit tests: 295/295 pass
- [ ] Manual: place multiple multi-lane roads — no React key warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure unique and stable React keys for canvas-based road visuals and tighten typing for drawing overlay elements.

Bug Fixes:
- Prevent React key collisions for shoulder and sidewalk lines within road segments by incorporating the road object ID into keys.
- Prevent React key collisions for lane markings in polyline, curve, and cubic bezier road shapes by prefixing keys with the road object ID.
- Disambiguate cubic bezier tangent preview keys in drawing overlays based on control point count to avoid duplicate keys.

Enhancements:
- Type the drawing overlay elements collection as React.ReactNode[] to avoid implicit any and clarify expected content.