### PR TITLE
feat(coord-bridge): plan JSON v1→v2 coordinate bridge (#194)

### DIFF
--- a/docs/migration-v1-v2-runbook.md
+++ b/docs/migration-v1-v2-runbook.md
@@ -57,8 +57,8 @@ GeoSpace (lat/lng)   — WGS84 for map display, DXF, PostGIS
 Given live React state `{ offset, zoom, canvasSize, mapCenter, mapZoom }`:
 
 ```
-screenX = worldX * zoom + offset.x
-screenY = worldY * zoom + offset.y
+screenX = worldX * canvasZoom + canvasOffset.x
+screenY = worldY * canvasZoom + canvasOffset.y
 
 // mapCenter sits at screen center (useMapTiles invariant):
 originScreenX = canvasSize.w / 2
@@ -168,7 +168,7 @@ export function geoToPlan(ll: LatLng, geo: GeoContext): PlanPt
 
 ### New: `my-app/src/coordinate-bridge.test.ts`
 
-- `groundResolution(17, 37.7749)` ≈ 0.596 m/px (Web Mercator reference value)
+- `groundResolution(17, 37.7749)` ≈ 0.944 m/px (Web Mercator reference value at SF latitude)
 - Round-trip: `screenToPlan(planToScreen(pt, vp, geo), vp, geo) ≈ pt` within 0.001 m
 - Round-trip: `geoToPlan(planToGeo(pt, geo), geo) ≈ pt` within 0.001 m
 - `planToScreen` with `offset={0,0}, zoom=1`: origin maps to `originScreenPx`
@@ -279,7 +279,7 @@ aws s3api get-bucket-versioning --bucket YOUR_BUCKET_NAME
 ## Acceptance checklist
 
 - [ ] S3 versioning enabled on production bucket before merging
-- [ ] `groundResolution(17, 37.7749)` ≈ 0.596 m/px (Web Mercator reference)
+- [ ] `groundResolution(17, 37.7749)` ≈ 0.944 m/px (Web Mercator reference)
 - [ ] `coordinate-bridge` round-trip tests pass within 0.001 m epsilon
 - [ ] `planMigration` fixture: world → save v2 → load v2 → world within 1 px
 - [ ] v1 plan loads unchanged; objects render in correct positions

--- a/docs/migration-v1-v2-runbook.md
+++ b/docs/migration-v1-v2-runbook.md
@@ -1,8 +1,8 @@
 # Plan JSON v1 → v2 Migration Runbook
 
 **Issue:** #194  
-**Status:** Spec — pending implementation  
-**Branch:** TBD (`feat/coord-bridge-194`)
+**Status:** Implemented — merged via PR #257  
+**Branch:** `feat/coord-bridge-194`
 
 ---
 

--- a/docs/migration-v1-v2-runbook.md
+++ b/docs/migration-v1-v2-runbook.md
@@ -1,0 +1,289 @@
+# Plan JSON v1 → v2 Migration Runbook
+
+**Issue:** #194  
+**Status:** Spec — pending implementation  
+**Branch:** TBD (`feat/coord-bridge-194`)
+
+---
+
+## Why this exists
+
+v1 plans store object coordinates as **Konva world-space pixel values** (layer-local, before layer transform). These are viewport-dependent: they change meaning on zoom, pan, resize, and export crop — making them unsuitable for DXF export, AI sign placement, comment anchoring, and real-time collaboration.
+
+v2 plans store object coordinates in **plan space (meters from the plan origin)**, with a `geoContext` block providing the ground resolution and map anchor needed to convert between plan space, screen pixels, and WGS84/EPSG:3857.
+
+---
+
+## Scope of this PR
+
+| In scope | Out of scope |
+|---|---|
+| `coordinate-bridge` module (`groundResolution`, `buildGeoContext`, `planToScreen`, `screenToPlan`, `worldToPlan`, `planToWorld`, `planToGeo`, `geoToPlan`) | Canvas renderer switch to plan-space rendering (Phase 4) |
+| Schema v2 writes for new saves with a `mapCenter` set | Batch migration of existing v1 plans on S3 |
+| Load path: detect v1 (use as-is) and v2 (convert back to pixels for current renderer) | DXF Lambda coordinate wiring |
+| Migration runbook (this doc) | S3 key rename (`userId` → `tenantId`) |
+
+**Why no offline batch migration?**  
+The migration formula requires `canvasSize` (the browser canvas dimensions at save time). This is not stored in v1 plans — it depends on the user's window at the moment of saving. Without it, coordinate transforms are inaccurate. The correct strategy is to upgrade plans **at save time**, when `canvasSize` is live in React state.
+
+**Why not bump `PLAN_SCHEMA_VERSION` to 2 for plans without `mapCenter`?**  
+Plans with no geo anchor cannot produce a valid `geoContext`. They stay at v1 indefinitely; a warning banner prompts the user to add a map location.
+
+---
+
+## Coordinate spaces
+
+```
+WorldSpace (px)      — Konva layer-local coords; stored in v1 objects; offset+zoom applied at render
+     ↕  (offset, zoom, canvasSize) — all live in React state; NOT stored in v1 plans
+ScreenSpace (px)     — Konva stage pixels; ephemeral; screen.x = world.x * zoom + offset.x
+     ↕  canvasSize: mapCenter is anchored at (canvasSize.w/2, canvasSize.h/2) in screen space
+                     (because useMapTiles always tiles around the viewport center)
+MercatorPixels       — internal to useMapTiles; tile math at the map's zoom level
+     ↕  groundResolution (meters/px at reference zoom + lat)
+PlanSpace (m)        — meters from plan origin (= mapCenter); stable; stored in v2
+     ↕  GeoContext
+GeoSpace (lat/lng)   — WGS84 for map display, DXF, PostGIS
+```
+
+**Key constraint:** `canvasSize` is live state, not persisted in v1. Migration to plan space is therefore only accurate when the canvas is active.
+
+---
+
+## Coordinate transform derivation
+
+### World → plan space (used at save time)
+
+Given live React state `{ offset, zoom, canvasSize, mapCenter, mapZoom }`:
+
+```
+screenX = worldX * zoom + offset.x
+screenY = worldY * zoom + offset.y
+
+// mapCenter sits at screen center (useMapTiles invariant):
+originScreenX = canvasSize.w / 2
+originScreenY = canvasSize.h / 2
+
+// Delta from mapCenter in screen pixels:
+ΔscreenX = screenX − originScreenX  =  worldX * zoom + offset.x − canvasSize.w/2
+ΔscreenY = screenY − originScreenY  =  worldY * zoom + offset.y − canvasSize.h/2
+
+// Convert to meters (Y axis flipped: canvas +Y is down, plan space +Y is north):
+planX =  ΔscreenX * groundRes
+planY = −ΔscreenY * groundRes
+```
+
+### Plan space → world (used at load time for v2 plans)
+
+v2 plans continue to store `canvasZoom` and `canvasOffset` (as v1 does) for viewport restoration. The load path uses those stored values together with the **current live `canvasSize`**:
+
+```
+ΔscreenX = planX / groundRes
+ΔscreenY = −planY / groundRes
+
+// mapCenter is always at screen center at the current canvasSize:
+screenX = ΔscreenX + canvasSize_current.w / 2
+screenY = ΔscreenY + canvasSize_current.h / 2
+
+// Invert world→screen using the stored viewport:
+worldX = (screenX − stored_canvasOffset.x) / stored_canvasZoom
+worldY = (screenY − stored_canvasOffset.y) / stored_canvasZoom
+```
+
+`canvasSize_current` is the live React state at load time, not a stored value. If the user's browser window is a different size than at save time, objects shift by `Δ(canvasSize.w/2)` in screen pixels — acceptable for the current pixel-space renderer (see Failure modes).
+
+**Two-zoom invariant:**  
+- `groundRes` uses `mapZoom` (the map tile zoom level; drives ground resolution in m/px).  
+- World→screen uses `canvasZoom` (the Konva layer scale; drives how big objects appear on screen).  
+These are independent: panning/zooming the canvas changes `canvasZoom` and `canvasOffset`; changing the map base layer changes `mapZoom`. Plan-space meters are always in ground units at `mapZoom`; `canvasZoom` affects only how many screen pixels each world pixel occupies.
+
+---
+
+## GeoContext block (written to v2 plans)
+
+```typescript
+interface GeoContext {
+  mapCenter: { lat: number; lng: number }; // WGS84 anchor; same as plan-level mapCenter
+  mapZoom: number;                          // reference zoom (same as plan-level mapZoom)
+  groundResolutionMetersPerPx: number;      // meters/px at reference zoom + lat
+  originScreenPx: { x: number; y: number };// screen pixel of mapCenter at time of save
+                                            // = { x: canvasSize.w/2, y: canvasSize.h/2 }
+  crs: "EPSG:3857";                         // canonical projection for planToGeo / geoToPlan
+}
+```
+
+`groundResolutionMetersPerPx` formula (Web Mercator):
+```
+(2π × 6_378_137) / (256 × 2^zoom) × cos(lat × π / 180)
+```
+
+> **Note:** The architecture doc (§15) uses `originCanvasPx`. This runbook renames the field to `originScreenPx` to prevent confusion with `canvasOffset` (the Konva layer translation / pan). The two are distinct:  
+> - `canvasOffset` = where world (0,0) lands on the stage (pan offset, stored in v1).  
+> - `originScreenPx` = screen pixel of mapCenter = always `(canvasSize.w/2, canvasSize.h/2)` regardless of pan.
+
+---
+
+## Files
+
+### New: `my-app/src/coordinate-bridge.ts`
+
+Pure math module — no React, no S3, no side effects.
+
+```typescript
+export interface GeoContext {
+  mapCenter: { lat: number; lng: number };
+  mapZoom: number;
+  groundResolutionMetersPerPx: number;
+  originScreenPx: { x: number; y: number };
+  crs: 'EPSG:3857';
+}
+export interface ViewportState { offsetX: number; offsetY: number; zoom: number }
+export interface WorldPt  { x: number; y: number }  // Konva layer-local pixels (world space)
+export interface PlanPt   { x: number; y: number }  // meters from mapCenter (plan space)
+export interface ScreenPt { x: number; y: number }  // Konva stage pixels (screen space)
+export interface LatLng   { lat: number; lng: number }
+
+/** meters/px at the given zoom level and latitude (Web Mercator) */
+export function groundResolution(zoom: number, lat: number): number
+
+/** Build a GeoContext from live canvas state (call at save time) */
+export function buildGeoContext(
+  mapCenter: { lat: number; lng: number },
+  mapZoom: number,
+  canvasSize: { w: number; h: number },
+): GeoContext
+
+/** PlanSpace ↔ ScreenSpace */
+export function planToScreen(pt: PlanPt, viewport: ViewportState, geo: GeoContext): ScreenPt
+export function screenToPlan(pt: ScreenPt, viewport: ViewportState, geo: GeoContext): PlanPt
+
+/** WorldSpace ↔ PlanSpace (combines world→screen→plan) */
+export function worldToPlan(pt: WorldPt, viewport: ViewportState, geo: GeoContext): PlanPt
+export function planToWorld(pt: PlanPt, viewport: ViewportState, geo: GeoContext): WorldPt
+
+/** PlanSpace ↔ GeoSpace (stable; no viewport needed) */
+export function planToGeo(pt: PlanPt, geo: GeoContext): LatLng
+export function geoToPlan(ll: LatLng, geo: GeoContext): PlanPt
+```
+
+### New: `my-app/src/coordinate-bridge.test.ts`
+
+- `groundResolution(17, 37.7749)` ≈ 0.596 m/px (Web Mercator reference value)
+- Round-trip: `screenToPlan(planToScreen(pt, vp, geo), vp, geo) ≈ pt` within 0.001 m
+- Round-trip: `geoToPlan(planToGeo(pt, geo), geo) ≈ pt` within 0.001 m
+- `planToScreen` with `offset={0,0}, zoom=1`: origin maps to `originScreenPx`
+- Non-zero offset and zoom round-trip
+- Edge cases: negative plan coords, zoom 1 and zoom 20
+
+### New: `my-app/src/planMigration.ts`
+
+```typescript
+export type SchemaVersion = 1 | 2;
+
+export function detectSchemaVersion(plan: Record<string, unknown>): SchemaVersion
+
+/** Convert v2 plan-space object coords back to world pixels for the current renderer.
+ *  canvasSize is live React state at load time.
+ *  canvasOffset and canvasZoom are read from the plan's stored fields. */
+export function v2ToWorldCoords(
+  plan: Record<string, unknown>,
+  canvasSize: { w: number; h: number },
+): Record<string, unknown>
+// internally uses plan.canvasOffset and plan.canvasZoom from the stored plan
+
+export interface MigrationStats {
+  objectCount: number;
+  convertedCount: number;
+  skippedCount: number;  // objects without recognised coord fields
+}
+```
+
+Note: there is no `migrateV1ToV2` offline batch function. v1 → v2 upgrade happens at **save time** inside `handleCloudSave` / `savePlan`, using live canvas state.
+
+### New: `my-app/src/planMigration.test.ts`
+
+- **Fixture 1 (v2 load → world coords)**: known plan-space sign position → expected world coords within 1 px, with `canvasSize = {w:800, h:600}`, `offset={0,0}`, `zoom=1`
+- **Fixture 2 (v2 load → world coords)**: road with polyline points — all points converted correctly
+- **Fixture 3 (v1 pass-through)**: v1 plan detected, returned unchanged from `v2ToWorldCoords`
+- **Fixture 4**: known world-space sign position → save as v2 → load v2 → world coords within 1 px (round-trip through `buildGeoContext` + `v2ToWorldCoords`)
+
+### Modified: `my-app/src/planStorage.ts`
+
+**`loadPlanFromCloud`**: after version check, if schema v2, call `v2ToWorldCoords` before returning. Callers (the planner) receive world-pixel coordinates as always and need no changes.
+
+### Modified: `my-app/src/traffic-control-planner.tsx`
+
+- **`loadPlan` (disk load)**: same v2 detection + `v2ToWorldCoords` using current `canvasSize`
+- **`handleCloudSave` + `savePlan`**: if `mapCenter` is set, call `buildGeoContext` + convert all object world coords to plan space; write v2. If no `mapCenter`, write v1 as today
+- **Warning banner**: if a loaded plan is v1 with no `mapCenter`, show a dismissible banner: _"This plan has no map location — geo-referenced export is unavailable. Use ⌖ to set a location."_
+- **`PLAN_SCHEMA_VERSION`**: bump to 2 (plans with `mapCenter` will now write v2; plans without `mapCenter` continue writing v1 until a location is set)
+
+---
+
+## Decisions
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Auto-upgrade on load or prompt? | **Transparent at save**: user sees no prompt; v2 is written on next explicit ☁ Save | Upgrade happens at a natural moment; no disruptive dialog |
+| Rollback policy | **Rely on S3 versioning** (must be enabled on the bucket) | Free, automatic; prior v1 always recoverable via S3 console |
+| Plans without `mapCenter` | **Leave as v1; show warning banner** | No geo anchor → can't compute GeoContext; forced migration corrupts coords |
+| Offline batch migration | **Not implemented** | `canvasSize` not stored in v1; offline transform is inaccurate without it |
+
+---
+
+## Rollback procedure
+
+S3 versioning must be enabled before any v2 saves reach production (see setup below). Every save creates a new S3 object version; no manual backup step is needed.
+
+**Restore a single plan to v1:**
+1. S3 console → `plans/{userId}/{planId}.tcp.json` → Show versions
+2. Select the version predating the first v2 save → Download or restore
+
+**Bulk rollback (scripted):**
+```bash
+aws s3api list-object-versions --bucket $BUCKET --prefix plans/ \
+  | jq '.Versions[] | select(.IsLatest == false and .LastModified < "2026-XX-XX")'
+# Then restore each by copying the desired VersionId back as the latest
+```
+
+---
+
+## S3 versioning setup
+
+Must be enabled **before** v2 writes are deployed to production.
+
+```bash
+aws s3api put-bucket-versioning \
+  --bucket YOUR_BUCKET_NAME \
+  --versioning-configuration Status=Enabled
+
+# Verify:
+aws s3api get-bucket-versioning --bucket YOUR_BUCKET_NAME
+# → { "Status": "Enabled" }
+```
+
+---
+
+## Failure modes
+
+| Failure | Behaviour | Recovery |
+|---|---|---|
+| v1 plan with no `mapCenter` | Loaded as v1; warning banner; saves as v1 | Set map location, re-save |
+| v2 plan loaded with different `canvasSize` than at save | Objects shift by `Δ(canvasSize.w/2)` screen pixels — positions are anchored to viewport center, which moves with window size. This is not a coordinate corruption; re-save from the new window size to re-anchor. | Pan to re-center; re-save |
+| `groundResolution` at extreme zoom (< 1 or > 22) | Clamp to zoom [1, 20] range | N/A — TCP maps are always in this range |
+| Object with unrecognised coord shape | Logged to console, counted in `skippedCount`, object left in world pixels | Manual correction in editor |
+| S3 versioning not enabled | v2 save proceeds; prior v1 unrecoverable | Enable versioning before deploying |
+
+---
+
+## Acceptance checklist
+
+- [ ] S3 versioning enabled on production bucket before merging
+- [ ] `groundResolution(17, 37.7749)` ≈ 0.596 m/px (Web Mercator reference)
+- [ ] `coordinate-bridge` round-trip tests pass within 0.001 m epsilon
+- [ ] `planMigration` fixture: world → save v2 → load v2 → world within 1 px
+- [ ] v1 plan loads unchanged; objects render in correct positions
+- [ ] v2 plan loads correctly with `v2ToWorldCoords`; objects render in correct positions
+- [ ] Plans without `mapCenter` show warning banner; save as v1
+- [ ] `PLAN_SCHEMA_VERSION = 2` written for saves with `mapCenter`
+- [ ] Visual sanity check: open a real saved plan before and after PR; object positions match

--- a/my-app/src/PlanDashboard.tsx
+++ b/my-app/src/PlanDashboard.tsx
@@ -3,6 +3,7 @@ import { CloudPlanMeta, listCloudPlans, loadPlanFromCloud, deletePlanFromCloud }
 
 interface PlanDashboardProps {
   userId: string
+  canvasSize: { w: number; h: number }
   onOpen: (plan: Record<string, unknown>) => void
   onClose: () => void
 }
@@ -46,7 +47,7 @@ const S: Record<string, React.CSSProperties> = {
   footer: { padding: '12px 20px', borderTop: '1px solid #2d3048', flexShrink: 0, fontSize: 10, color: '#64748b' },
 }
 
-export default function PlanDashboard({ userId, onOpen, onClose }: PlanDashboardProps) {
+export default function PlanDashboard({ userId, canvasSize, onOpen, onClose }: PlanDashboardProps) {
   const [plans, setPlans] = useState<CloudPlanMeta[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -71,7 +72,7 @@ export default function PlanDashboard({ userId, onOpen, onClose }: PlanDashboard
     setOpening(plan.path)
     setError(null)
     try {
-      const data = await loadPlanFromCloud(plan.path)
+      const data = await loadPlanFromCloud(plan.path, canvasSize)
       setOpening(null)
       onOpen(data)
     } catch (e) {

--- a/my-app/src/coordinate-bridge.ts
+++ b/my-app/src/coordinate-bridge.ts
@@ -68,6 +68,9 @@ export function buildGeoContext(
 /**
  * Convert a plan-space point (meters from mapCenter) to screen pixels.
  * Canvas +Y is down; plan space +Y is north — Y axis is flipped.
+ * Note: viewport is not used for plan↔screen conversion (mapCenter is always
+ * anchored at originScreenPx regardless of pan/zoom). It is kept in the signature
+ * to mirror worldToPlan/planToWorld so callers can pass a uniform ViewportState.
  */
 export function planToScreen(pt: PlanPt, _viewport: ViewportState, geo: GeoContext): ScreenPt {
   return {
@@ -76,7 +79,10 @@ export function planToScreen(pt: PlanPt, _viewport: ViewportState, geo: GeoConte
   }
 }
 
-/** Convert a screen-pixel point to plan space (meters from mapCenter). */
+/**
+ * Convert a screen-pixel point to plan space (meters from mapCenter).
+ * viewport is intentionally unused — see planToScreen for rationale.
+ */
 export function screenToPlan(pt: ScreenPt, _viewport: ViewportState, geo: GeoContext): PlanPt {
   return {
     x:  (pt.x - geo.originScreenPx.x) * geo.groundResolutionMetersPerPx,
@@ -115,23 +121,33 @@ export function planToWorld(pt: PlanPt, viewport: ViewportState, geo: GeoContext
 /**
  * Convert a plan-space point (meters from mapCenter) to WGS84 lat/lng.
  * Stable — no viewport needed.
+ *
+ * Uses a local spherical approximation (small-angle degrees-per-meter), which is
+ * accurate to well under 1 m for TCP plan extents (< 5 km). This is NOT a full
+ * EPSG:3857 Mercator projection; crs is declared for downstream consumers
+ * (DXF, PostGIS) and reflects the intended projected space, not this conversion.
  */
 export function planToGeo(pt: PlanPt, geo: GeoContext): LatLng {
-  // For latitude, use the small-angle approximation over short distances
   const metersPerDegreeLat = (2 * Math.PI * 6_378_137) / 360
-  const metersPerDegreeLng = metersPerDegreeLat * Math.cos(geo.mapCenter.lat * Math.PI / 180)
+  const cosLat = Math.cos(geo.mapCenter.lat * Math.PI / 180)
+  // Guard: cos approaches 0 above ~89.9° lat — TCP plans never operate there,
+  // but clamp to avoid infinities from malformed data.
+  const metersPerDegreeLng = metersPerDegreeLat * Math.max(cosLat, 1e-10)
 
-  // pt.x / pt.y are already meters east/north from mapCenter in plan space
   return {
     lat: geo.mapCenter.lat + pt.y / metersPerDegreeLat,
     lng: geo.mapCenter.lng + pt.x / metersPerDegreeLng,
   }
 }
 
-/** Convert WGS84 lat/lng to plan-space meters from mapCenter. */
+/**
+ * Convert WGS84 lat/lng to plan-space meters from mapCenter.
+ * Uses the same local spherical approximation as planToGeo.
+ */
 export function geoToPlan(ll: LatLng, geo: GeoContext): PlanPt {
   const metersPerDegreeLat = (2 * Math.PI * 6_378_137) / 360
-  const metersPerDegreeLng = metersPerDegreeLat * Math.cos(geo.mapCenter.lat * Math.PI / 180)
+  const cosLat = Math.cos(geo.mapCenter.lat * Math.PI / 180)
+  const metersPerDegreeLng = metersPerDegreeLat * Math.max(cosLat, 1e-10)
 
   return {
     x: (ll.lng - geo.mapCenter.lng) * metersPerDegreeLng,

--- a/my-app/src/coordinate-bridge.ts
+++ b/my-app/src/coordinate-bridge.ts
@@ -1,0 +1,140 @@
+/**
+ * Coordinate bridge — pure math module for converting between coordinate spaces.
+ *
+ * Spaces:
+ *   WorldSpace  (px)  — Konva layer-local coords; stored in v1 objects
+ *   ScreenSpace (px)  — Konva stage pixels; ephemeral
+ *   PlanSpace   (m)   — meters from mapCenter; stable; stored in v2
+ *   GeoSpace          — WGS84 lat/lng
+ *
+ * No React, no S3, no side effects.
+ */
+
+export interface GeoContext {
+  mapCenter: { lat: number; lng: number }
+  mapZoom: number
+  groundResolutionMetersPerPx: number
+  /** Screen pixel of mapCenter = { x: canvasSize.w/2, y: canvasSize.h/2 } at save time */
+  originScreenPx: { x: number; y: number }
+  crs: 'EPSG:3857'
+}
+
+export interface ViewportState {
+  /** Konva layer translation (pan) — where world (0,0) lands on the stage */
+  offsetX: number
+  offsetY: number
+  /** Konva layer scale */
+  zoom: number
+}
+
+/** Konva layer-local pixels (world space) */
+export interface WorldPt { x: number; y: number }
+/** Meters from mapCenter (plan space) */
+export interface PlanPt  { x: number; y: number }
+/** Konva stage pixels (screen space) */
+export interface ScreenPt { x: number; y: number }
+export interface LatLng   { lat: number; lng: number }
+
+/**
+ * Ground resolution in meters per pixel at the given map zoom level and latitude.
+ * Formula: (2π × 6_378_137) / (256 × 2^zoom) × cos(lat × π / 180)
+ * Zoom is clamped to [1, 20].
+ */
+export function groundResolution(zoom: number, lat: number): number {
+  const clampedZoom = Math.max(1, Math.min(20, zoom))
+  return (2 * Math.PI * 6_378_137) / (256 * Math.pow(2, clampedZoom)) * Math.cos(lat * Math.PI / 180)
+}
+
+/**
+ * Build a GeoContext from live canvas state. Call at save time when canvasSize is available.
+ * mapCenter is always anchored at (canvasSize.w/2, canvasSize.h/2) per useMapTiles invariant.
+ */
+export function buildGeoContext(
+  mapCenter: { lat: number; lng: number },
+  mapZoom: number,
+  canvasSize: { w: number; h: number },
+): GeoContext {
+  return {
+    mapCenter,
+    mapZoom,
+    groundResolutionMetersPerPx: groundResolution(mapZoom, mapCenter.lat),
+    originScreenPx: { x: canvasSize.w / 2, y: canvasSize.h / 2 },
+    crs: 'EPSG:3857',
+  }
+}
+
+// ─── PlanSpace ↔ ScreenSpace ──────────────────────────────────────────────────
+
+/**
+ * Convert a plan-space point (meters from mapCenter) to screen pixels.
+ * Canvas +Y is down; plan space +Y is north — Y axis is flipped.
+ */
+export function planToScreen(pt: PlanPt, _viewport: ViewportState, geo: GeoContext): ScreenPt {
+  return {
+    x: geo.originScreenPx.x + pt.x / geo.groundResolutionMetersPerPx,
+    y: geo.originScreenPx.y - pt.y / geo.groundResolutionMetersPerPx,
+  }
+}
+
+/** Convert a screen-pixel point to plan space (meters from mapCenter). */
+export function screenToPlan(pt: ScreenPt, _viewport: ViewportState, geo: GeoContext): PlanPt {
+  return {
+    x:  (pt.x - geo.originScreenPx.x) * geo.groundResolutionMetersPerPx,
+    y: -(pt.y - geo.originScreenPx.y) * geo.groundResolutionMetersPerPx,
+  }
+}
+
+// ─── WorldSpace ↔ PlanSpace ───────────────────────────────────────────────────
+
+/**
+ * Convert a world-space point (Konva layer-local pixels) to plan space (meters).
+ * Combines world→screen→plan using the live viewport.
+ */
+export function worldToPlan(pt: WorldPt, viewport: ViewportState, geo: GeoContext): PlanPt {
+  const screen: ScreenPt = {
+    x: pt.x * viewport.zoom + viewport.offsetX,
+    y: pt.y * viewport.zoom + viewport.offsetY,
+  }
+  return screenToPlan(screen, viewport, geo)
+}
+
+/**
+ * Convert a plan-space point (meters) back to world-space pixels.
+ * Uses the stored viewport (canvasZoom + canvasOffset) from the plan.
+ */
+export function planToWorld(pt: PlanPt, viewport: ViewportState, geo: GeoContext): WorldPt {
+  const screen = planToScreen(pt, viewport, geo)
+  return {
+    x: (screen.x - viewport.offsetX) / viewport.zoom,
+    y: (screen.y - viewport.offsetY) / viewport.zoom,
+  }
+}
+
+// ─── PlanSpace ↔ GeoSpace ─────────────────────────────────────────────────────
+
+/**
+ * Convert a plan-space point (meters from mapCenter) to WGS84 lat/lng.
+ * Stable — no viewport needed.
+ */
+export function planToGeo(pt: PlanPt, geo: GeoContext): LatLng {
+  // For latitude, use the small-angle approximation over short distances
+  const metersPerDegreeLat = (2 * Math.PI * 6_378_137) / 360
+  const metersPerDegreeLng = metersPerDegreeLat * Math.cos(geo.mapCenter.lat * Math.PI / 180)
+
+  // pt.x / pt.y are already meters east/north from mapCenter in plan space
+  return {
+    lat: geo.mapCenter.lat + pt.y / metersPerDegreeLat,
+    lng: geo.mapCenter.lng + pt.x / metersPerDegreeLng,
+  }
+}
+
+/** Convert WGS84 lat/lng to plan-space meters from mapCenter. */
+export function geoToPlan(ll: LatLng, geo: GeoContext): PlanPt {
+  const metersPerDegreeLat = (2 * Math.PI * 6_378_137) / 360
+  const metersPerDegreeLng = metersPerDegreeLat * Math.cos(geo.mapCenter.lat * Math.PI / 180)
+
+  return {
+    x: (ll.lng - geo.mapCenter.lng) * metersPerDegreeLng,
+    y: (ll.lat - geo.mapCenter.lat) * metersPerDegreeLat,
+  }
+}

--- a/my-app/src/planMigration.ts
+++ b/my-app/src/planMigration.ts
@@ -1,0 +1,153 @@
+/**
+ * Plan schema version detection and coordinate migration helpers.
+ *
+ * v1 plans store object coordinates in Konva world-space pixels.
+ * v2 plans store object coordinates in plan space (meters from mapCenter).
+ *
+ * v1 → v2 upgrade happens at save time (inside handleCloudSave) when live
+ * canvas state is available. There is no offline batch migration because
+ * canvasSize is not stored in v1 plans.
+ *
+ * v2 → world: done at load time using the stored viewport (canvasOffset,
+ * canvasZoom) and the live canvasSize from React state.
+ */
+
+import { planToWorld, buildGeoContext, type ViewportState, type PlanPt, type GeoContext } from './coordinate-bridge'
+
+export type SchemaVersion = 1 | 2
+
+/**
+ * Detect the schema version of a raw plan object.
+ * A plan is v2 if it has `_schemaVersion === 2` and a valid `geoContext` block.
+ */
+export function detectSchemaVersion(plan: Record<string, unknown>): SchemaVersion {
+  if (
+    plan._schemaVersion === 2 &&
+    plan.geoContext !== null &&
+    typeof plan.geoContext === 'object'
+  ) {
+    return 2
+  }
+  return 1
+}
+
+export interface MigrationStats {
+  objectCount: number
+  convertedCount: number
+  skippedCount: number
+}
+
+/**
+ * Convert all plan-space object coordinates back to world pixels for the
+ * current renderer. Called at load time for v2 plans.
+ *
+ * canvasSize is live React state at load time.
+ * canvasOffset and canvasZoom are read from the stored plan fields.
+ *
+ * v1 plans are returned unchanged.
+ */
+export function v2ToWorldCoords(
+  plan: Record<string, unknown>,
+  canvasSize: { w: number; h: number },
+): { plan: Record<string, unknown>; stats: MigrationStats } {
+  if (detectSchemaVersion(plan) !== 2) {
+    const objects = getObjects(plan)
+    return { plan, stats: { objectCount: objects.length, convertedCount: 0, skippedCount: 0 } }
+  }
+
+  const geo = resolveGeoContext(plan, canvasSize)
+  const viewport = resolveViewport(plan)
+  const objects = getObjects(plan)
+
+  let convertedCount = 0
+  let skippedCount = 0
+
+  const convertedObjects = objects.map((obj) => {
+    const result = convertObjectToWorld(obj, viewport, geo)
+    if (result.converted) {
+      convertedCount++
+    } else {
+      skippedCount++
+      console.warn('[planMigration] Skipped object with unrecognised coord shape:', obj)
+    }
+    return result.obj
+  })
+
+  return {
+    plan: {
+      ...plan,
+      canvasState: { ...(plan.canvasState as Record<string, unknown>), objects: convertedObjects },
+    },
+    stats: { objectCount: objects.length, convertedCount, skippedCount },
+  }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function getObjects(plan: Record<string, unknown>): Record<string, unknown>[] {
+  const cs = plan.canvasState
+  if (cs && typeof cs === 'object' && Array.isArray((cs as Record<string, unknown>).objects)) {
+    return (cs as Record<string, unknown>).objects as Record<string, unknown>[]
+  }
+  return []
+}
+
+/** Reconstruct a GeoContext from the stored geoContext block, overriding originScreenPx
+ *  with the live canvasSize so the viewport center anchor is correct for the current window. */
+function resolveGeoContext(plan: Record<string, unknown>, canvasSize: { w: number; h: number }): GeoContext {
+  const stored = plan.geoContext as Record<string, unknown>
+  const mapCenter = stored.mapCenter as { lat: number; lng: number }
+  const mapZoom = stored.mapZoom as number
+  // Rebuild from live canvasSize — the map anchor is always at the viewport center.
+  return buildGeoContext(mapCenter, mapZoom, canvasSize)
+}
+
+function resolveViewport(plan: Record<string, unknown>): ViewportState {
+  return {
+    offsetX: typeof plan.canvasOffset === 'object' && plan.canvasOffset !== null
+      ? ((plan.canvasOffset as Record<string, unknown>).x as number) ?? 0
+      : 0,
+    offsetY: typeof plan.canvasOffset === 'object' && plan.canvasOffset !== null
+      ? ((plan.canvasOffset as Record<string, unknown>).y as number) ?? 0
+      : 0,
+    zoom: typeof plan.canvasZoom === 'number' ? plan.canvasZoom : 1,
+  }
+}
+
+/** Convert a single canvas object's plan-space coords to world pixels. */
+function convertObjectToWorld(
+  obj: Record<string, unknown>,
+  viewport: ViewportState,
+  geo: GeoContext,
+): { obj: Record<string, unknown>; converted: boolean } {
+  // Sign / device / zone / text / taper / turn_lane: { x, y }
+  if (typeof obj.x === 'number' && typeof obj.y === 'number') {
+    const world = planToWorld({ x: obj.x, y: obj.y } as PlanPt, viewport, geo)
+    return { obj: { ...obj, x: world.x, y: world.y }, converted: true }
+  }
+
+  // Straight road / arrow / measure / lane_mask / crosswalk: { x1, y1, x2, y2 }
+  if (
+    typeof obj.x1 === 'number' && typeof obj.y1 === 'number' &&
+    typeof obj.x2 === 'number' && typeof obj.y2 === 'number'
+  ) {
+    const w1 = planToWorld({ x: obj.x1, y: obj.y1 } as PlanPt, viewport, geo)
+    const w2 = planToWorld({ x: obj.x2, y: obj.y2 } as PlanPt, viewport, geo)
+    return { obj: { ...obj, x1: w1.x, y1: w1.y, x2: w2.x, y2: w2.y }, converted: true }
+  }
+
+  // Polyline / curve / cubic_bezier road: { points: Array<{x,y}> }
+  if (Array.isArray(obj.points) && obj.points.length > 0 && isPt(obj.points[0])) {
+    const pts = obj.points as PlanPt[]
+    const converted = pts.map((p) => planToWorld(p, viewport, geo))
+    return { obj: { ...obj, points: converted }, converted: true }
+  }
+
+  return { obj, converted: false }
+}
+
+function isPt(v: unknown): v is PlanPt {
+  return typeof v === 'object' && v !== null &&
+    typeof (v as Record<string, unknown>).x === 'number' &&
+    typeof (v as Record<string, unknown>).y === 'number'
+}

--- a/my-app/src/planMigration.ts
+++ b/my-app/src/planMigration.ts
@@ -18,17 +18,38 @@ export type SchemaVersion = 1 | 2
 
 /**
  * Detect the schema version of a raw plan object.
- * A plan is v2 if it has `_schemaVersion === 2` and a valid `geoContext` block.
+ * A plan is v2 if it has `_schemaVersion === 2` AND a structurally valid `geoContext`
+ * (mapCenter with finite lat/lng numbers, finite mapZoom).
+ *
+ * A plan with `_schemaVersion === 2` but a missing or malformed `geoContext` is treated
+ * as v1 with a console warning — this prevents NaN from propagating silently if a plan
+ * was partially written.
  */
 export function detectSchemaVersion(plan: Record<string, unknown>): SchemaVersion {
-  if (
-    plan._schemaVersion === 2 &&
-    plan.geoContext !== null &&
-    typeof plan.geoContext === 'object'
-  ) {
-    return 2
+  if (plan._schemaVersion !== 2) return 1
+
+  if (!isValidGeoContext(plan.geoContext)) {
+    console.warn(
+      '[planMigration] Plan has _schemaVersion=2 but invalid or missing geoContext — treating as v1.',
+      plan.geoContext,
+    )
+    return 1
   }
-  return 1
+
+  return 2
+}
+
+function isValidGeoContext(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false
+  const gc = value as Record<string, unknown>
+  const mc = gc.mapCenter
+  if (mc === null || typeof mc !== 'object') return false
+  const { lat, lng } = mc as Record<string, unknown>
+  return (
+    typeof lat === 'number' && Number.isFinite(lat) &&
+    typeof lng === 'number' && Number.isFinite(lng) &&
+    typeof gc.mapZoom === 'number' && Number.isFinite(gc.mapZoom as number)
+  )
 }
 
 export interface MigrationStats {
@@ -62,16 +83,26 @@ export function v2ToWorldCoords(
   let convertedCount = 0
   let skippedCount = 0
 
+  const skippedObjects: Record<string, unknown>[] = []
+
   const convertedObjects = objects.map((obj) => {
     const result = convertObjectToWorld(obj, viewport, geo)
     if (result.converted) {
       convertedCount++
     } else {
       skippedCount++
-      console.warn('[planMigration] Skipped object with unrecognised coord shape:', obj)
+      skippedObjects.push(obj)
     }
     return result.obj
   })
+
+  if (skippedObjects.length > 0) {
+    console.warn(
+      `[planMigration] ${skippedObjects.length} object(s) had unrecognised coordinate shapes and were left in plan-space. ` +
+      'They may render incorrectly. IDs:',
+      skippedObjects.map((o) => o.id ?? '(no id)'),
+    )
+  }
 
   return {
     plan: {
@@ -93,13 +124,24 @@ function getObjects(plan: Record<string, unknown>): Record<string, unknown>[] {
 }
 
 /** Reconstruct a GeoContext from the stored geoContext block, overriding originScreenPx
- *  with the live canvasSize so the viewport center anchor is correct for the current window. */
+ *  with the live canvasSize so the viewport center anchor is correct for the current window.
+ *  Throws with a descriptive message if geoContext fields are missing or non-finite. */
 function resolveGeoContext(plan: Record<string, unknown>, canvasSize: { w: number; h: number }): GeoContext {
   const stored = plan.geoContext as Record<string, unknown>
-  const mapCenter = stored.mapCenter as { lat: number; lng: number }
+  const mc = stored.mapCenter as Record<string, unknown>
+  const lat = mc?.lat as number
+  const lng = mc?.lng as number
   const mapZoom = stored.mapZoom as number
+
+  if (!Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(mapZoom)) {
+    throw new Error(
+      `[planMigration] Invalid geoContext in v2 plan: mapCenter=${JSON.stringify(mc)}, mapZoom=${mapZoom}. ` +
+      'Cannot convert plan-space coordinates without a valid geo anchor.'
+    )
+  }
+
   // Rebuild from live canvasSize — the map anchor is always at the viewport center.
-  return buildGeoContext(mapCenter, mapZoom, canvasSize)
+  return buildGeoContext({ lat, lng }, mapZoom, canvasSize)
 }
 
 function resolveViewport(plan: Record<string, unknown>): ViewportState {
@@ -113,6 +155,11 @@ function resolveViewport(plan: Record<string, unknown>): ViewportState {
     zoom: typeof plan.canvasZoom === 'number' ? plan.canvasZoom : 1,
   }
 }
+
+// TODO(#194): The object-type → coord-shape mapping here mirrors the one in
+// performCloudSave (traffic-control-planner.tsx). If a new CanvasObject type is
+// added, both places must be updated. Consider centralizing into a shared
+// objectCoordFields() helper to prevent mixed-unit objects.
 
 /** Convert a single canvas object's plan-space coords to world pixels. */
 function convertObjectToWorld(

--- a/my-app/src/planStorage.ts
+++ b/my-app/src/planStorage.ts
@@ -7,9 +7,10 @@
  * All functions throw on failure — callers are responsible for error handling.
  */
 
-/** Increment when the stored plan shape changes in a breaking way. */
-export const PLAN_SCHEMA_VERSION = 1
+/** Maximum schema version this build can read. Increment when the stored plan shape changes. */
+export const PLAN_SCHEMA_VERSION = 2
 import { uploadData, list, getUrl, remove, getProperties } from 'aws-amplify/storage'
+import { v2ToWorldCoords, detectSchemaVersion } from './planMigration'
 
 export interface CloudPlanMeta {
   path: string
@@ -19,11 +20,16 @@ export interface CloudPlanMeta {
   size: number
 }
 
-/** Upload (create or overwrite) a plan to S3. The `updatedAt` field is also written to S3 user metadata for conflict detection. */
+/** Upload (create or overwrite) a plan to S3. The `updatedAt` field is also written to S3 user metadata for conflict detection.
+ *  If `data._schemaVersion` is already set, it is preserved; otherwise PLAN_SCHEMA_VERSION is used. */
 export async function savePlanToCloud(userId: string, planId: string, data: object & { updatedAt: string }): Promise<void> {
+  const dataWithVersion = {
+    _schemaVersion: PLAN_SCHEMA_VERSION,
+    ...data,
+  }
   await uploadData({
     path: `plans/${userId}/${planId}.tcp.json`,
-    data: JSON.stringify({ ...data, _schemaVersion: PLAN_SCHEMA_VERSION }),
+    data: JSON.stringify(dataWithVersion),
     options: { contentType: 'application/json', metadata: { updatedAt: data.updatedAt } },
   }).result
 }
@@ -70,8 +76,15 @@ export async function listCloudPlans(userId: string): Promise<CloudPlanMeta[]> {
     .sort((a, b) => b.lastModified.localeCompare(a.lastModified))
 }
 
-/** Fetch and parse a plan from S3 by its path. */
-export async function loadPlanFromCloud(path: string): Promise<Record<string, unknown>> {
+/**
+ * Fetch and parse a plan from S3 by its path.
+ * If the plan is v2, converts plan-space coordinates back to world pixels using
+ * the live canvasSize before returning, so callers always receive world-pixel coords.
+ */
+export async function loadPlanFromCloud(
+  path: string,
+  canvasSize: { w: number; h: number },
+): Promise<Record<string, unknown>> {
   const { url } = await getUrl({ path, options: { expiresIn: 60 } })
   const res = await fetch(url.toString())
   if (!res.ok) throw new Error(`Failed to fetch plan (${res.status})`)
@@ -79,6 +92,10 @@ export async function loadPlanFromCloud(path: string): Promise<Record<string, un
   const version = typeof data._schemaVersion === 'number' ? data._schemaVersion : 0
   if (version > PLAN_SCHEMA_VERSION) {
     throw new Error(`Plan was saved with a newer version of TCPlanPro (v${version}). Please refresh the app.`)
+  }
+  if (detectSchemaVersion(data) === 2) {
+    const { plan } = v2ToWorldCoords(data, canvasSize)
+    return plan
   }
   return data
 }

--- a/my-app/src/test/PlanDashboard.test.tsx
+++ b/my-app/src/test/PlanDashboard.test.tsx
@@ -13,6 +13,8 @@ const mockPlan: CloudPlanMeta = {
   size: 512,
 }
 
+const CANVAS_SIZE = { w: 800, h: 600 }
+
 beforeEach(() => {
   vi.restoreAllMocks()
 })
@@ -20,13 +22,13 @@ beforeEach(() => {
 describe('PlanDashboard', () => {
   it('shows loading state then empty message when no plans exist', async () => {
     vi.spyOn(planStorage, 'listCloudPlans').mockResolvedValue([])
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={vi.fn()} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={vi.fn()} />)
     await waitFor(() => expect(screen.getByTestId('dashboard-empty')).toBeInTheDocument())
   })
 
   it('renders a plan row after listing returns one plan', async () => {
     vi.spyOn(planStorage, 'listCloudPlans').mockResolvedValue([mockPlan])
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={vi.fn()} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={vi.fn()} />)
     await waitFor(() => expect(screen.getByTestId('dashboard-plan-row')).toBeInTheDocument())
   })
 
@@ -36,10 +38,10 @@ describe('PlanDashboard', () => {
     vi.spyOn(planStorage, 'loadPlanFromCloud').mockResolvedValue(planData)
     const onOpen = vi.fn()
     const user = userEvent.setup()
-    render(<PlanDashboard userId="user-1" onOpen={onOpen} onClose={vi.fn()} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={onOpen} onClose={vi.fn()} />)
     await waitFor(() => screen.getByTestId('dashboard-open-btn'))
     await user.click(screen.getByTestId('dashboard-open-btn'))
-    await waitFor(() => expect(planStorage.loadPlanFromCloud).toHaveBeenCalledWith(mockPlan.path))
+    await waitFor(() => expect(planStorage.loadPlanFromCloud).toHaveBeenCalledWith(mockPlan.path, CANVAS_SIZE))
     expect(onOpen).toHaveBeenCalledWith(planData)
   })
 
@@ -47,7 +49,7 @@ describe('PlanDashboard', () => {
     vi.spyOn(planStorage, 'listCloudPlans').mockResolvedValue([mockPlan])
     vi.spyOn(planStorage, 'loadPlanFromCloud').mockRejectedValue(new Error('S3 error'))
     const user = userEvent.setup()
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={vi.fn()} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={vi.fn()} />)
     await waitFor(() => screen.getByTestId('dashboard-open-btn'))
     await user.click(screen.getByTestId('dashboard-open-btn'))
     await waitFor(() =>
@@ -60,7 +62,7 @@ describe('PlanDashboard', () => {
     vi.spyOn(planStorage, 'deletePlanFromCloud').mockResolvedValue()
     vi.spyOn(globalThis, 'confirm').mockReturnValue(true)
     const user = userEvent.setup()
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={vi.fn()} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={vi.fn()} />)
     await waitFor(() => screen.getByTestId('dashboard-delete-btn'))
     await user.click(screen.getByTestId('dashboard-delete-btn'))
     await waitFor(() => expect(planStorage.deletePlanFromCloud).toHaveBeenCalledWith(mockPlan.path))
@@ -72,7 +74,7 @@ describe('PlanDashboard', () => {
     const deleteSpy = vi.spyOn(planStorage, 'deletePlanFromCloud').mockResolvedValue()
     vi.spyOn(globalThis, 'confirm').mockReturnValue(false)
     const user = userEvent.setup()
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={vi.fn()} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={vi.fn()} />)
     await waitFor(() => screen.getByTestId('dashboard-delete-btn'))
     await user.click(screen.getByTestId('dashboard-delete-btn'))
     expect(deleteSpy).not.toHaveBeenCalled()
@@ -83,7 +85,7 @@ describe('PlanDashboard', () => {
     vi.spyOn(planStorage, 'listCloudPlans').mockResolvedValue([])
     const onClose = vi.fn()
     const user = userEvent.setup()
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={onClose} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={onClose} />)
     await user.click(screen.getByTestId('dashboard-close'))
     expect(onClose).toHaveBeenCalled()
   })
@@ -91,7 +93,7 @@ describe('PlanDashboard', () => {
   it('calls onClose when clicking outside the modal', async () => {
     vi.spyOn(planStorage, 'listCloudPlans').mockResolvedValue([])
     const onClose = vi.fn()
-    render(<PlanDashboard userId="user-1" onOpen={vi.fn()} onClose={onClose} />)
+    render(<PlanDashboard userId="user-1" canvasSize={CANVAS_SIZE} onOpen={vi.fn()} onClose={onClose} />)
     await waitFor(() => screen.getByTestId('plan-dashboard-overlay'))
     fireEvent.click(screen.getByTestId('plan-dashboard-overlay'))
     expect(onClose).toHaveBeenCalled()

--- a/my-app/src/test/coordinate-bridge.test.ts
+++ b/my-app/src/test/coordinate-bridge.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  groundResolution,
+  buildGeoContext,
+  planToScreen,
+  screenToPlan,
+  worldToPlan,
+  planToWorld,
+  planToGeo,
+  geoToPlan,
+  type ViewportState,
+  type PlanPt,
+  type WorldPt,
+} from '../coordinate-bridge'
+
+const SF_LAT = 37.7749
+const SF_LNG = -122.4194
+
+const GEO = buildGeoContext(
+  { lat: SF_LAT, lng: SF_LNG },
+  17,
+  { w: 800, h: 600 },
+)
+
+const VP_IDENTITY: ViewportState = { offsetX: 0, offsetY: 0, zoom: 1 }
+
+// ─── groundResolution ─────────────────────────────────────────────────────────
+
+describe('groundResolution', () => {
+  it('returns ~0.944 m/px at zoom 17, lat 37.7749 (Web Mercator reference)', () => {
+    // (2π × 6_378_137) / (256 × 2^17) × cos(37.7749° × π/180) ≈ 0.9440
+    expect(groundResolution(17, SF_LAT)).toBeCloseTo(0.944, 2)
+  })
+
+  it('clamps zoom below 1 to 1', () => {
+    expect(groundResolution(0, SF_LAT)).toBe(groundResolution(1, SF_LAT))
+    expect(groundResolution(-5, SF_LAT)).toBe(groundResolution(1, SF_LAT))
+  })
+
+  it('clamps zoom above 20 to 20', () => {
+    expect(groundResolution(21, SF_LAT)).toBe(groundResolution(20, SF_LAT))
+    expect(groundResolution(100, SF_LAT)).toBe(groundResolution(20, SF_LAT))
+  })
+
+  it('increases at lower zoom levels (more meters per pixel)', () => {
+    expect(groundResolution(10, SF_LAT)).toBeGreaterThan(groundResolution(17, SF_LAT))
+  })
+})
+
+// ─── buildGeoContext ──────────────────────────────────────────────────────────
+
+describe('buildGeoContext', () => {
+  it('sets originScreenPx to canvas center', () => {
+    const geo = buildGeoContext({ lat: SF_LAT, lng: SF_LNG }, 17, { w: 1024, h: 768 })
+    expect(geo.originScreenPx).toEqual({ x: 512, y: 384 })
+  })
+
+  it('sets crs to EPSG:3857', () => {
+    expect(GEO.crs).toBe('EPSG:3857')
+  })
+
+  it('stores mapCenter and mapZoom', () => {
+    expect(GEO.mapCenter).toEqual({ lat: SF_LAT, lng: SF_LNG })
+    expect(GEO.mapZoom).toBe(17)
+  })
+})
+
+// ─── planToScreen / screenToPlan round-trip ───────────────────────────────────
+
+describe('planToScreen / screenToPlan round-trip', () => {
+  const pts: PlanPt[] = [
+    { x: 0, y: 0 },
+    { x: 100, y: 50 },
+    { x: -200, y: -100 },
+    { x: 0.001, y: -0.001 },
+  ]
+
+  for (const pt of pts) {
+    it(`round-trips ${JSON.stringify(pt)} within 0.001 m`, () => {
+      const screen = planToScreen(pt, VP_IDENTITY, GEO)
+      const back = screenToPlan(screen, VP_IDENTITY, GEO)
+      expect(back.x).toBeCloseTo(pt.x, 3)
+      expect(back.y).toBeCloseTo(pt.y, 3)
+    })
+  }
+
+  it('origin (0, 0) maps to originScreenPx with identity viewport', () => {
+    const screen = planToScreen({ x: 0, y: 0 }, VP_IDENTITY, GEO)
+    expect(screen.x).toBeCloseTo(GEO.originScreenPx.x, 3)
+    expect(screen.y).toBeCloseTo(GEO.originScreenPx.y, 3)
+  })
+
+  it('positive planY maps to screen Y below originScreenPx (canvas +Y down)', () => {
+    const above = planToScreen({ x: 0, y: 100 }, VP_IDENTITY, GEO)
+    expect(above.y).toBeLessThan(GEO.originScreenPx.y)
+  })
+})
+
+// ─── worldToPlan / planToWorld round-trip ─────────────────────────────────────
+
+describe('worldToPlan / planToWorld round-trip', () => {
+  const vp: ViewportState = { offsetX: 50, offsetY: -30, zoom: 1.5 }
+
+  const pts: WorldPt[] = [
+    { x: 0, y: 0 },
+    { x: 100, y: 200 },
+    { x: -50, y: -75 },
+  ]
+
+  for (const pt of pts) {
+    it(`round-trips world pt ${JSON.stringify(pt)} within 0.001 m`, () => {
+      const plan = worldToPlan(pt, vp, GEO)
+      const back = planToWorld(plan, vp, GEO)
+      expect(back.x).toBeCloseTo(pt.x, 3)
+      expect(back.y).toBeCloseTo(pt.y, 3)
+    })
+  }
+
+  it('identity viewport: world (0,0) maps to same plan coords as screen origin → plan', () => {
+    const worldOriginPlan = worldToPlan({ x: 0, y: 0 }, VP_IDENTITY, GEO)
+    const screenOriginPlan = screenToPlan({ x: 0, y: 0 }, VP_IDENTITY, GEO)
+    expect(worldOriginPlan.x).toBeCloseTo(screenOriginPlan.x, 6)
+    expect(worldOriginPlan.y).toBeCloseTo(screenOriginPlan.y, 6)
+  })
+})
+
+// ─── planToGeo / geoToPlan round-trip ────────────────────────────────────────
+
+describe('planToGeo / geoToPlan round-trip', () => {
+  const pts: PlanPt[] = [
+    { x: 0, y: 0 },
+    { x: 500, y: 300 },
+    { x: -1000, y: -800 },
+    { x: 0.5, y: -0.5 },
+  ]
+
+  for (const pt of pts) {
+    it(`round-trips ${JSON.stringify(pt)} within 0.001 m`, () => {
+      const ll = planToGeo(pt, GEO)
+      const back = geoToPlan(ll, GEO)
+      expect(back.x).toBeCloseTo(pt.x, 3)
+      expect(back.y).toBeCloseTo(pt.y, 3)
+    })
+  }
+
+  it('plan origin (0,0) maps to mapCenter lat/lng', () => {
+    const ll = planToGeo({ x: 0, y: 0 }, GEO)
+    expect(ll.lat).toBeCloseTo(SF_LAT, 6)
+    expect(ll.lng).toBeCloseTo(SF_LNG, 6)
+  })
+
+  it('positive x (east) increases longitude', () => {
+    const ll = planToGeo({ x: 1000, y: 0 }, GEO)
+    expect(ll.lng).toBeGreaterThan(SF_LNG)
+  })
+
+  it('positive y (north) increases latitude', () => {
+    const ll = planToGeo({ x: 0, y: 1000 }, GEO)
+    expect(ll.lat).toBeGreaterThan(SF_LAT)
+  })
+})
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe('edge cases', () => {
+  it('works at zoom 1', () => {
+    const geo = buildGeoContext({ lat: SF_LAT, lng: SF_LNG }, 1, { w: 800, h: 600 })
+    const pt: PlanPt = { x: 100, y: 50 }
+    const back = screenToPlan(planToScreen(pt, VP_IDENTITY, geo), VP_IDENTITY, geo)
+    expect(back.x).toBeCloseTo(pt.x, 3)
+    expect(back.y).toBeCloseTo(pt.y, 3)
+  })
+
+  it('works at zoom 20', () => {
+    const geo = buildGeoContext({ lat: SF_LAT, lng: SF_LNG }, 20, { w: 800, h: 600 })
+    const pt: PlanPt = { x: 1, y: -1 }
+    const back = screenToPlan(planToScreen(pt, VP_IDENTITY, geo), VP_IDENTITY, geo)
+    expect(back.x).toBeCloseTo(pt.x, 3)
+    expect(back.y).toBeCloseTo(pt.y, 3)
+  })
+
+  it('negative plan coords round-trip correctly', () => {
+    const pt: PlanPt = { x: -500, y: -300 }
+    const screen = planToScreen(pt, VP_IDENTITY, GEO)
+    const back = screenToPlan(screen, VP_IDENTITY, GEO)
+    expect(back.x).toBeCloseTo(pt.x, 3)
+    expect(back.y).toBeCloseTo(pt.y, 3)
+  })
+
+  it('non-zero viewport zoom + offset round-trip', () => {
+    const vp: ViewportState = { offsetX: -123, offsetY: 456, zoom: 2.5 }
+    const pt: WorldPt = { x: 300, y: -150 }
+    const plan = worldToPlan(pt, vp, GEO)
+    const back = planToWorld(plan, vp, GEO)
+    expect(back.x).toBeCloseTo(pt.x, 3)
+    expect(back.y).toBeCloseTo(pt.y, 3)
+  })
+})

--- a/my-app/src/test/planMigration.test.ts
+++ b/my-app/src/test/planMigration.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { detectSchemaVersion, v2ToWorldCoords } from '../planMigration'
+import { buildGeoContext, worldToPlan, type ViewportState } from '../coordinate-bridge'
+
+// Shared test parameters
+const MAP_CENTER = { lat: 37.7749, lng: -122.4194 }
+const MAP_ZOOM = 17
+const CANVAS_SIZE = { w: 800, h: 600 }
+const VIEWPORT: ViewportState = { offsetX: 0, offsetY: 0, zoom: 1 }
+
+const GEO = buildGeoContext(MAP_CENTER, MAP_ZOOM, CANVAS_SIZE)
+
+function makeV2Plan(objects: Record<string, unknown>[], viewport = VIEWPORT) {
+  return {
+    _schemaVersion: 2,
+    geoContext: GEO,
+    canvasOffset: { x: viewport.offsetX, y: viewport.offsetY },
+    canvasZoom: viewport.zoom,
+    canvasState: { objects },
+  }
+}
+
+function makeV1Plan(objects: Record<string, unknown>[]) {
+  return {
+    _schemaVersion: 1,
+    canvasState: { objects },
+  }
+}
+
+// ─── detectSchemaVersion ──────────────────────────────────────────────────────
+
+describe('detectSchemaVersion', () => {
+  it('returns 2 for a plan with _schemaVersion=2 and geoContext', () => {
+    expect(detectSchemaVersion(makeV2Plan([]))).toBe(2)
+  })
+
+  it('returns 1 for a plan with _schemaVersion=1', () => {
+    expect(detectSchemaVersion(makeV1Plan([]))).toBe(1)
+  })
+
+  it('returns 1 for a plan with no _schemaVersion', () => {
+    expect(detectSchemaVersion({ canvasState: { objects: [] } })).toBe(1)
+  })
+
+  it('returns 1 for a plan with _schemaVersion=2 but no geoContext', () => {
+    expect(detectSchemaVersion({ _schemaVersion: 2, canvasState: { objects: [] } })).toBe(1)
+  })
+})
+
+// ─── Fixture 1: v2 load → world coords (sign with x/y) ───────────────────────
+
+describe('v2ToWorldCoords — Fixture 1: sign (x/y point)', () => {
+  it('converts a known plan-space sign position to expected world coords within 1 px', () => {
+    // Place a sign at world (200, 150) and record its plan-space coords
+    const worldPt = { x: 200, y: 150 }
+    const planPt = worldToPlan(worldPt, VIEWPORT, GEO)
+
+    const plan = makeV2Plan([{ type: 'sign', id: '1', x: planPt.x, y: planPt.y }])
+    const { plan: out, stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
+
+    const objs = (out.canvasState as { objects: Record<string, unknown>[] }).objects
+    expect(objs[0].x as number).toBeCloseTo(worldPt.x, 0)
+    expect(objs[0].y as number).toBeCloseTo(worldPt.y, 0)
+    expect(stats.convertedCount).toBe(1)
+    expect(stats.skippedCount).toBe(0)
+  })
+})
+
+// ─── Fixture 2: v2 load → world coords (road with points array) ──────────────
+
+describe('v2ToWorldCoords — Fixture 2: road with polyline points', () => {
+  it('converts all polyline points correctly (Point[] format)', () => {
+    const worldPts = [{ x: 100, y: 200 }, { x: 300, y: 400 }, { x: 500, y: 600 }]
+    const planPts = worldPts.map(p => worldToPlan(p, VIEWPORT, GEO))  // Array<{x,y}>
+
+    const plan = makeV2Plan([{ type: 'polyline_road', id: '2', points: planPts }])
+    const { plan: out, stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
+
+    const objs = (out.canvasState as { objects: Record<string, unknown>[] }).objects
+    const outPts = objs[0].points as { x: number; y: number }[]
+    for (let i = 0; i < worldPts.length; i++) {
+      expect(outPts[i].x).toBeCloseTo(worldPts[i].x, 0)
+      expect(outPts[i].y).toBeCloseTo(worldPts[i].y, 0)
+    }
+    expect(stats.convertedCount).toBe(1)
+    expect(stats.skippedCount).toBe(0)
+  })
+
+  it('converts x1/y1/x2/y2 straight road correctly', () => {
+    const w1 = { x: 50, y: 100 }
+    const w2 = { x: 400, y: 300 }
+    const p1 = worldToPlan(w1, VIEWPORT, GEO)
+    const p2 = worldToPlan(w2, VIEWPORT, GEO)
+
+    const plan = makeV2Plan([{ type: 'road', id: '3', x1: p1.x, y1: p1.y, x2: p2.x, y2: p2.y }])
+    const { plan: out, stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
+
+    const objs = (out.canvasState as { objects: Record<string, unknown>[] }).objects
+    expect(objs[0].x1 as number).toBeCloseTo(w1.x, 0)
+    expect(objs[0].y1 as number).toBeCloseTo(w1.y, 0)
+    expect(objs[0].x2 as number).toBeCloseTo(w2.x, 0)
+    expect(objs[0].y2 as number).toBeCloseTo(w2.y, 0)
+    expect(stats.convertedCount).toBe(1)
+    expect(stats.skippedCount).toBe(0)
+  })
+})
+
+// ─── Fixture 3: v1 pass-through ───────────────────────────────────────────────
+
+describe('v2ToWorldCoords — Fixture 3: v1 plan pass-through', () => {
+  it('returns v1 plan unchanged', () => {
+    const objects = [{ type: 'sign', id: '3', x: 100, y: 200 }]
+    const plan = makeV1Plan(objects)
+    const { plan: out, stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
+
+    const objs = (out.canvasState as { objects: Record<string, unknown>[] }).objects
+    expect(objs[0].x).toBe(100)
+    expect(objs[0].y).toBe(200)
+    expect(stats.convertedCount).toBe(0)
+    expect(stats.skippedCount).toBe(0)
+    expect(stats.objectCount).toBe(1)
+  })
+})
+
+// ─── Fixture 4: round-trip world → save v2 plan → load v2 → world ────────────
+
+describe('v2ToWorldCoords — Fixture 4: full round-trip', () => {
+  it('world → buildGeoContext + plan coords → v2ToWorldCoords → world within 1 px', () => {
+    const worldPt = { x: 350, y: 275 }
+    const planPt = worldToPlan(worldPt, VIEWPORT, GEO)
+
+    // Simulate what handleCloudSave writes: plan-space coords + geoContext
+    const saved = makeV2Plan([{ type: 'device', id: '4', x: planPt.x, y: planPt.y }])
+
+    // Simulate load path
+    const { plan: loaded } = v2ToWorldCoords(saved, CANVAS_SIZE)
+
+    const objs = (loaded.canvasState as { objects: Record<string, unknown>[] }).objects
+    expect(objs[0].x as number).toBeCloseTo(worldPt.x, 0)
+    expect(objs[0].y as number).toBeCloseTo(worldPt.y, 0)
+  })
+
+  it('round-trips cubic bezier road (points array format) within 1 px', () => {
+    // CubicBezierRoadObject uses points: [p0, cp1, cp2, p3] — same Point[] serialization
+    const worldPts = [
+      { x: 100, y: 100 },  // p0 start
+      { x: 200, y: 50 },   // cp1
+      { x: 400, y: 350 },  // cp2
+      { x: 500, y: 300 },  // p3 end
+    ]
+    const planPts = worldPts.map(p => worldToPlan(p, VIEWPORT, GEO))
+
+    const saved = makeV2Plan([{
+      type: 'cubic_bezier_road',
+      id: '5',
+      points: planPts,
+    }])
+
+    const { plan: loaded } = v2ToWorldCoords(saved, CANVAS_SIZE)
+    const obj = (loaded.canvasState as { objects: Record<string, unknown>[] }).objects[0]
+    const outPts = obj.points as { x: number; y: number }[]
+
+    for (let i = 0; i < worldPts.length; i++) {
+      expect(outPts[i].x).toBeCloseTo(worldPts[i].x, 0)
+      expect(outPts[i].y).toBeCloseTo(worldPts[i].y, 0)
+    }
+  })
+})
+
+// ─── Skipped objects ──────────────────────────────────────────────────────────
+
+describe('v2ToWorldCoords — skipped objects', () => {
+  it('counts objects with unrecognised coord shape in skippedCount', () => {
+    const plan = makeV2Plan([
+      { type: 'sign', id: 'a', x: 0, y: 0 },           // converted
+      { type: 'unknown', id: 'b', someField: 'value' },  // skipped
+    ])
+    const { stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
+    expect(stats.convertedCount).toBe(1)
+    expect(stats.skippedCount).toBe(1)
+  })
+})

--- a/my-app/src/test/planMigration.test.ts
+++ b/my-app/src/test/planMigration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { detectSchemaVersion, v2ToWorldCoords } from '../planMigration'
 import { buildGeoContext, worldToPlan, type ViewportState } from '../coordinate-bridge'
 
@@ -42,8 +42,28 @@ describe('detectSchemaVersion', () => {
     expect(detectSchemaVersion({ canvasState: { objects: [] } })).toBe(1)
   })
 
-  it('returns 1 for a plan with _schemaVersion=2 but no geoContext', () => {
+  it('returns 1 for a plan with _schemaVersion=2 but no geoContext, and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     expect(detectSchemaVersion({ _schemaVersion: 2, canvasState: { objects: [] } })).toBe(1)
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid or missing geoContext'), undefined)
+    warnSpy.mockRestore()
+  })
+
+  it('returns 1 for a plan with _schemaVersion=2 but geoContext missing mapCenter, and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(detectSchemaVersion({ _schemaVersion: 2, geoContext: { mapZoom: 17 } })).toBe(1)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
+  })
+
+  it('returns 1 for a plan with _schemaVersion=2 but NaN in geoContext, and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(detectSchemaVersion({
+      _schemaVersion: 2,
+      geoContext: { mapCenter: { lat: NaN, lng: -122 }, mapZoom: 17 },
+    })).toBe(1)
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 })
 
@@ -170,13 +190,47 @@ describe('v2ToWorldCoords — Fixture 4: full round-trip', () => {
 // ─── Skipped objects ──────────────────────────────────────────────────────────
 
 describe('v2ToWorldCoords — skipped objects', () => {
-  it('counts objects with unrecognised coord shape in skippedCount', () => {
+  it('counts objects with unrecognised coord shape in skippedCount and emits one aggregated warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const plan = makeV2Plan([
-      { type: 'sign', id: 'a', x: 0, y: 0 },           // converted
-      { type: 'unknown', id: 'b', someField: 'value' },  // skipped
+      { type: 'sign', id: 'a', x: 0, y: 0 },            // converted
+      { type: 'unknown', id: 'b', someField: 'value' },   // skipped
+      { type: 'unknown', id: 'c', otherField: 123 },      // skipped
     ])
     const { stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
     expect(stats.convertedCount).toBe(1)
-    expect(stats.skippedCount).toBe(1)
+    expect(stats.skippedCount).toBe(2)
+    // Only one aggregated warning, not one per object
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('2 object(s)'),
+      expect.arrayContaining(['b', 'c']),
+    )
+    warnSpy.mockRestore()
+  })
+})
+
+// ─── resolveViewport defaults ─────────────────────────────────────────────────
+
+describe('v2ToWorldCoords — resolveViewport defaults', () => {
+  it('uses offset={0,0} and zoom=1 when canvasOffset and canvasZoom are absent', () => {
+    const worldPt = { x: 200, y: 150 }
+    const planPt = worldToPlan(worldPt, VIEWPORT, GEO)  // VIEWPORT is identity
+
+    // Build a v2 plan with no canvasOffset / canvasZoom fields
+    const plan: Record<string, unknown> = {
+      _schemaVersion: 2,
+      geoContext: GEO,
+      // canvasOffset omitted
+      // canvasZoom omitted
+      canvasState: { objects: [{ type: 'sign', id: 'x', x: planPt.x, y: planPt.y }] },
+    }
+
+    const { plan: out, stats } = v2ToWorldCoords(plan, CANVAS_SIZE)
+    const objs = (out.canvasState as { objects: Record<string, unknown>[] }).objects
+    // With default offset=(0,0) zoom=1, should round-trip to original world coords
+    expect(objs[0].x as number).toBeCloseTo(worldPt.x, 0)
+    expect(objs[0].y as number).toBeCloseTo(worldPt.y, 0)
+    expect(stats.convertedCount).toBe(1)
   })
 })

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -10,6 +10,8 @@ import type {
 } from './types';
 import { uid, geoRoadWidthPx, formatSearchPrimary, geocodeAddress, cloneObject } from './utils';
 import { savePlanToCloud, fetchRemoteUpdatedAt, loadPlanFromCloud } from './planStorage';
+import { buildGeoContext, worldToPlan } from './coordinate-bridge';
+import { detectSchemaVersion, v2ToWorldCoords } from './planMigration';
 import PlanDashboard from './PlanDashboard';
 import TemplatePicker from './TemplatePicker';
 import ExportPreviewModal from './ExportPreviewModal';
@@ -66,6 +68,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
   const [bannerDismissed, setBannerDismissed] = useState(() => sessionStorage.getItem(BANNER_KEY) === '1');
   const [pdfSeen, setPdfSeen] = useState(() => sessionStorage.getItem(PDF_SEEN_KEY) === '1');
+  const [v1NoMapBanner, setV1NoMapBanner] = useState(false);
 
   const dismissBanner = () => { sessionStorage.setItem(BANNER_KEY, '1'); setBannerDismissed(true); };
 
@@ -436,14 +439,65 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   };
 
   // Shared upload logic — builds payload, uploads, updates state.
+  // Writes v2 (plan-space coordinates) when mapCenter is set; v1 otherwise.
   // Returns the new updatedAt on success; throws on failure.
   const performCloudSave = async (): Promise<string> => {
     const updatedAt = new Date().toISOString();
+    const viewport = { offsetX: offset.x, offsetY: offset.y, zoom };
+
+    let saveObjects: CanvasObject[] = objects;
+    let geoContext: ReturnType<typeof buildGeoContext> | null = null;
+    let schemaVersion = 1;
+
+    if (mapCenter) {
+      const geo = buildGeoContext(
+        { lat: mapCenter.lat, lng: mapCenter.lon },
+        mapCenter.zoom,
+        canvasSize,
+      );
+      geoContext = geo;
+      schemaVersion = 2;
+      saveObjects = objects.map((obj): CanvasObject => {
+        switch (obj.type) {
+          case 'sign':
+          case 'device':
+          case 'zone':
+          case 'text':
+          case 'taper':
+          case 'turn_lane': {
+            const p = worldToPlan({ x: obj.x, y: obj.y }, viewport, geo);
+            return { ...obj, x: p.x, y: p.y };
+          }
+          case 'road':
+          case 'arrow':
+          case 'measure':
+          case 'lane_mask':
+          case 'crosswalk': {
+            const p1 = worldToPlan({ x: obj.x1, y: obj.y1 }, viewport, geo);
+            const p2 = worldToPlan({ x: obj.x2, y: obj.y2 }, viewport, geo);
+            return { ...obj, x1: p1.x, y1: p1.y, x2: p2.x, y2: p2.y };
+          }
+          case 'polyline_road':
+          case 'curve_road':
+          case 'cubic_bezier_road': {
+            const pts = (obj.points as { x: number; y: number }[]).map(
+              (p) => worldToPlan(p, viewport, geo)
+            );
+            return { ...obj, points: pts } as CanvasObject;
+          }
+          default:
+            return obj;
+        }
+      });
+    }
+
     const data = {
+      _schemaVersion: schemaVersion,
       id: planId, name: planTitle, createdAt: planCreatedAt,
       updatedAt, userId: userId!,
-      canvasState: { objects }, metadata: planMeta,
+      canvasState: { objects: saveObjects }, metadata: planMeta,
       canvasOffset: offset, canvasZoom: zoom, mapCenter,
+      ...(geoContext ? { geoContext } : {}),
     };
     await savePlanToCloud(userId!, planId, data);
     setLastKnownUpdatedAt(updatedAt);
@@ -460,7 +514,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
         const path = `plans/${userId}/${planId}.tcp.json`;
         const remoteUpdatedAt = await fetchRemoteUpdatedAt(path);
         if (remoteUpdatedAt !== null && remoteUpdatedAt !== lastKnownUpdatedAt) {
-          const remotePlan = await loadPlanFromCloud(path);
+          const remotePlan = await loadPlanFromCloud(path, canvasSize);
           setConflictData(remotePlan);
           setCloudSaveStatus(null);
           return;
@@ -519,6 +573,9 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     setZoom(newZoom);
     setMapCenter(newMapCenter);
     setLastKnownUpdatedAt(typeof data.updatedAt === 'string' ? data.updatedAt : null);
+    // Show warning banner for v1 plans that have no geo anchor
+    const isV1NoMap = (typeof data._schemaVersion !== 'number' || data._schemaVersion < 2) && newMapCenter === null;
+    setV1NoMapBanner(isV1NoMap);
     setShowDashboard(false);
     track('plan_loaded_cloud', { object_count: newObjects.length });
   };
@@ -589,17 +646,25 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     const reader = new FileReader();
     reader.onload = (evt: ProgressEvent<FileReader>) => {
       try {
-        const plan = JSON.parse(evt.target!.result as string);
-        setPlanTitle(plan.name || "Untitled Traffic Control Plan");
-        setPlanId(plan.id || uid());
-        setPlanCreatedAt(plan.createdAt || new Date().toISOString());
-        setPlanMeta(plan.metadata || { projectNumber: "", client: "", location: "", notes: "" });
-        if (plan.mapCenter) setMapCenter({ lat: plan.mapCenter.lat, lon: plan.mapCenter.lng, zoom: plan.mapCenter.zoom });
-        if (plan.canvasOffset) setOffset(plan.canvasOffset);
-        if (plan.canvasZoom) setZoom(plan.canvasZoom);
-        const loaded: CanvasObject[] = plan.canvasState?.objects || [];
+        let plan = JSON.parse(evt.target!.result as string) as Record<string, unknown>;
+        if (detectSchemaVersion(plan) === 2) {
+          const { plan: migrated } = v2ToWorldCoords(plan, canvasSize);
+          plan = migrated;
+        }
+        setPlanTitle((plan.name as string | undefined) || "Untitled Traffic Control Plan");
+        setPlanId((plan.id as string | undefined) || uid());
+        setPlanCreatedAt((plan.createdAt as string | undefined) || new Date().toISOString());
+        setPlanMeta((plan.metadata as PlanMeta | undefined) || { projectNumber: "", client: "", location: "", notes: "" });
+        const rawMC = plan.mapCenter as { lat: number; lng?: number; lon?: number; zoom: number } | null | undefined;
+        const rawLon = rawMC?.lng ?? rawMC?.lon;
+        if (rawMC != null && rawLon != null) setMapCenter({ lat: rawMC.lat, lon: rawLon, zoom: rawMC.zoom });
+        if (plan.canvasOffset) setOffset(plan.canvasOffset as Point);
+        if (plan.canvasZoom) setZoom(plan.canvasZoom as number);
+        const loaded: CanvasObject[] = (plan.canvasState as { objects?: CanvasObject[] } | undefined)?.objects || [];
         pushHistory(loaded); setSelected(null);
         setLastKnownUpdatedAt(null); // local file load has no cloud version token
+        const wasV1NoMap = (detectSchemaVersion(plan) === 1) && (rawMC == null || rawLon == null);
+        setV1NoMapBanner(wasV1NoMap);
       } catch {
         alert("Failed to load plan. Make sure it's a valid .tcp.json file.");
       }
@@ -629,7 +694,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     setSearchQuery(formatSearchPrimary(result));
     const lat = Number(result?.lat), lon = Number(result?.lon);
     if (Number.isFinite(lat) && Number.isFinite(lon)) {
-      setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1);
+      setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1); setV1NoMapBanner(false);
       setSearchStatus(`Centered on ${formatSearchPrimary(result)}`);
     } else { setSearchStatus("Selected result has no coordinates."); }
     setSearchOpen(false);
@@ -668,6 +733,14 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
             <a href={`mailto:${CONTACT_EMAIL}`} style={{ color: COLORS.accent, textDecoration: "underline" }}>Report an issue</a>
           </span>
           <button onClick={dismissBanner} data-testid="dismiss-banner" style={{ background: "none", border: "none", color: COLORS.textDim, cursor: "pointer", fontSize: 14, lineHeight: 1, padding: "0 4px" }} title="Dismiss">✕</button>
+        </div>
+      )}
+      {v1NoMapBanner && (
+        <div data-testid="v1-no-map-banner" style={{ background: "rgba(245,158,11,0.12)", borderBottom: `1px solid rgba(245,158,11,0.3)`, padding: "6px 16px", display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0 }}>
+          <span style={{ fontSize: 11, color: COLORS.accent }}>
+            This plan has no map location — geo-referenced export is unavailable. Use the address search bar to set a location.
+          </span>
+          <button onClick={() => setV1NoMapBanner(false)} data-testid="dismiss-v1-no-map-banner" style={{ background: "none", border: "none", color: COLORS.textDim, cursor: "pointer", fontSize: 14, lineHeight: 1, padding: "0 4px" }} title="Dismiss">✕</button>
         </div>
       )}
 
@@ -1311,6 +1384,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
       {showDashboard && userId && CLOUD_ENABLED && (
         <PlanDashboard
           userId={userId}
+          canvasSize={canvasSize}
           onOpen={handleDashboardOpen}
           onClose={() => setShowDashboard(false)}
         />


### PR DESCRIPTION
## Summary

- Adds `coordinate-bridge.ts` — pure-math module with 8 transform functions between WorldSpace (Konva px), ScreenSpace (stage px), PlanSpace (meters from mapCenter), and GeoSpace (WGS84)
- Adds `planMigration.ts` — `detectSchemaVersion` + `v2ToWorldCoords` (handles `x/y`, `x1/y1/x2/y2`, and `points: Point[]` object shapes)
- `planStorage.ts`: `PLAN_SCHEMA_VERSION` bumped to 2; `loadPlanFromCloud` now takes `canvasSize` and converts v2 plans at load time
- `traffic-control-planner.tsx`: `performCloudSave` writes v2 (plan-space coords + `geoContext`) when `mapCenter` is set; `loadPlan` handles v2 disk files; warning banner for v1 plans with no map location
- `PlanDashboard.tsx`: new `canvasSize` prop forwarded to `loadPlanFromCloud`

## Key decisions (documented in `docs/migration-v1-v2-runbook.md`)

- No offline batch migration — `canvasSize` is not stored in v1 plans; upgrade happens at save time when canvas is live
- v1 plans without `mapCenter` stay v1 indefinitely and show a dismissible warning banner
- Rollback via S3 versioning (already enabled on all 4 TCP buckets)
- `groundResolution` reference value corrected to 0.944 m/px at zoom 17, lat 37.7749 (spec had 0.596, which is ≈60° latitude)

## Test plan

- [x] 39 new tests across `coordinate-bridge.test.ts` and `planMigration.test.ts`
- [x] All 360 tests pass
- [x] TypeScript clean (`tsc --noEmit`)
- [ ] Visual sanity check: open a real saved plan before and after — object positions match
- [ ] S3 versioning confirmed enabled on production bucket before merge

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a coordinate bridge and schema v2 plan format using plan-space coordinates with geo context, while maintaining backward compatibility by converting v2 coordinates back to world pixels on load and warning on legacy non-geo plans.

New Features:
- Add a pure math coordinate bridge module to convert between world, screen, plan, and geo coordinate spaces.
- Add plan migration utilities and schema detection to interpret and transform v2 plan-space coordinates.

Enhancements:
- Update cloud plan storage and dashboard loading paths to handle schema v2 plans using live canvas dimensions.
- Adjust planner save/load flows to write v2 plans when a map location is set and to surface a warning banner for legacy plans without geo anchors.

Documentation:
- Add a runbook documenting the v1 to v2 plan JSON migration strategy, coordinate model, and rollback approach.

Tests:
- Add comprehensive tests for the coordinate bridge math and v2 plan migration behaviour, including round-trips and fixture-based conversions.