### PR TITLE
feat(#195): render shoulders and sidewalks on polyline/curve/bezier roads

### DIFF
--- a/docs/shoulder-sidewalk-curved-roads-spec.md
+++ b/docs/shoulder-sidewalk-curved-roads-spec.md
@@ -1,0 +1,182 @@
+# Shoulder & Sidewalk Rendering on Curved Roads — Spec
+
+**Issue:** #195  
+**Status:** Spec — pending implementation  
+**Branch:** TBD (`feat/shoulder-sidewalk-195`)
+
+---
+
+## Problem
+
+`StraightRoadObject` renders shoulders and sidewalks correctly. `PolylineRoadObject`, `CurveRoadObject`, and `CubicBezierRoadObject` have the same data fields (`shoulderWidth`, `sidewalkWidth`, `sidewalkSide`) but their draw routines in `ObjectShapes.tsx` silently ignore them. Every polyline and bezier road with shoulders/sidewalks set renders with no shoulder or sidewalk visible.
+
+---
+
+## Scope
+
+| In scope | Out of scope |
+|---|---|
+| `PolylineRoad`, `CurveRoad`, `CubicBezierRoad` in `ObjectShapes.tsx` | `StraightRoadObject` (already works) |
+| New `buildOffsetSpine` utility in `utils.ts` | PropertyPanel UI (already exists) |
+| Unit tests for each road type | New road types or future road shapes |
+
+---
+
+## How StraightRoad does it (reference)
+
+`StraightRoadObject` renders shoulder and sidewalk as parallel `<Line>` elements computed from a single perpendicular normal vector `(nx, ny)`:
+
+```
+shoulder:   offset = hw + shoulderWidth / 2
+                     strokeWidth = shoulderWidth
+sidewalk:   swOff  = hw + shoulderWidth + sidewalkWidth / 2
+                     strokeWidth = sidewalkWidth
+```
+
+Colors:
+- Shoulder fill: `rgba(80,90,110,0.8)`
+- Sidewalk fill: `rgba(200,195,185,0.6)`
+- Sidewalk outer edge: `rgba(160,155,145,0.8)`, strokeWidth = 1
+
+Side logic:
+- `showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left'`
+- `showRight = sidewalkSide === 'both' || sidewalkSide === 'right'`
+
+---
+
+## Approach for curved roads
+
+### Core idea: offset spine
+
+Curved roads are already rendered by sampling a spine:
+- `CurveRoadObject`: `spine = sampleBezier(p0, p1, p2, 32)` — 33 points
+- `CubicBezierRoadObject`: `spine = sampleCubicBezier(p0, p1, p2, p3, 32)` — 33 points
+- `PolylineRoadObject`: spine = the control points array (`pts`), same as used for lane markings
+
+For each road type, shoulders and sidewalks are rendered by building an **offset spine**: each point of the original spine shifted by a perpendicular distance `d` in the normal direction.
+
+The normal at each point is computed from adjacent segment directions:
+- At interior points: use the outgoing segment direction
+- At the final point: use the incoming segment direction
+
+This produces a connected polyline that follows the road edge at a consistent offset, rendered as a single `<Line>` element.
+
+### New utility: `buildOffsetSpine(pts, d)`
+
+Add to `utils.ts`:
+
+```typescript
+/**
+ * Build a flat Konva points array offset perpendicular to the polyline by `d` pixels.
+ * Positive `d` is left of the direction of travel (canvas +Y down convention).
+ * Uses per-segment forward normals; the last point uses the last segment's normal.
+ */
+export function buildOffsetSpine(pts: Point[], d: number): number[]
+```
+
+Implementation:
+```typescript
+export function buildOffsetSpine(pts: Point[], d: number): number[] {
+  const result: number[] = []
+  for (let i = 0; i < pts.length; i++) {
+    // Use outgoing segment; fall back to incoming for the last point
+    const a = i < pts.length - 1 ? pts[i] : pts[i - 1]
+    const b = i < pts.length - 1 ? pts[i + 1] : pts[i]
+    const dx = b.x - a.x, dy = b.y - a.y
+    const len = Math.sqrt(dx * dx + dy * dy) || 1
+    const nx = -dy / len, ny = dx / len
+    result.push(pts[i].x + nx * d, pts[i].y + ny * d)
+  }
+  return result
+}
+```
+
+### Rendering in each component
+
+For each of `PolylineRoad`, `CurveRoad`, `CubicBezierRoad`:
+
+1. Destructure the shoulder/sidewalk fields from `obj` (same as `StraightRoad`):
+   ```tsx
+   const { shoulderWidth = 0, sidewalkWidth = 0, sidewalkSide } = obj
+   const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left'
+   const showRight = sidewalkSide === 'both' || sidewalkSide === 'right'
+   ```
+
+2. Compute offsets (same formula as `StraightRoad`):
+   ```tsx
+   const shoulderOff = hw + shoulderWidth / 2
+   const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2
+   ```
+
+3. Build shoulder lines (when `shoulderWidth > 0`):
+   ```tsx
+   const shoulderLines = shoulderWidth > 0 ? [
+     <Line key={`${id}-sl`}
+       points={buildOffsetSpine(spine, shoulderOff)}
+       stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth}
+       lineCap="round" lineJoin="round" listening={false} />,
+     <Line key={`${id}-sr`}
+       points={buildOffsetSpine(spine, -shoulderOff)}
+       stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth}
+       lineCap="round" lineJoin="round" listening={false} />,
+   ] : []
+   ```
+
+4. Build sidewalk lines (when `sidewalkWidth > 0 && sidewalkSide`), same left/right logic as `StraightRoad`.
+
+5. Render order (back to front, same as `StraightRoad`):
+   ```tsx
+   <Group listening={false}>
+     {sidewalkLines}   {/* furthest back */}
+     {shoulderLines}
+     ... road body ...
+   </Group>
+   ```
+
+### PolylineRoad spine note
+
+For `PolylineRoad`, the spine used for shoulder/sidewalk is the de-duplicated control points array `pts` — the same sequence used for lane markings. When `smooth=true`, the Konva `tension` parameter curves the road body between control points; the shoulder offset from those same control points will approximate (but not exactly match) the true curved edge. This is acceptable: the approximation error is small for the control-point densities used in practice, and matching the exact Catmull-Rom offset would require a dedicated sampler.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `my-app/src/utils.ts` | Add `buildOffsetSpine(pts, d)` |
+| `my-app/src/components/tcp/canvas/ObjectShapes.tsx` | Add shoulder/sidewalk to `PolylineRoad`, `CurveRoad`, `CubicBezierRoad` |
+| `my-app/src/test/objectShapes.test.ts` | New test file: one test per road type verifying shoulder/sidewalk elements are rendered |
+
+---
+
+## Visual spec
+
+The shoulder and sidewalk visuals must match `StraightRoad`:
+
+| Layer | Color | Width |
+|---|---|---|
+| Shoulder | `rgba(80,90,110,0.8)` | `shoulderWidth` |
+| Sidewalk fill | `rgba(200,195,185,0.6)` | `sidewalkWidth` |
+| Sidewalk outer edge | `rgba(160,155,145,0.8)` | 1 px |
+
+The `sidewalkSide` field controls which side(s) render:
+
+| Value | Left | Right |
+|---|---|---|
+| `'both'` | ✓ | ✓ |
+| `'left'` | ✓ | ✗ |
+| `'right'` | ✗ | ✓ |
+| `undefined` / unset | ✗ | ✗ |
+
+---
+
+## Acceptance checklist
+
+- [ ] `buildOffsetSpine` unit-tested in isolation
+- [ ] `PolylineRoad` with `shoulderWidth > 0` renders two shoulder `<Line>` elements
+- [ ] `PolylineRoad` with `sidewalkWidth > 0` and `sidewalkSide='both'` renders four sidewalk `<Line>` elements (two fills + two edges)
+- [ ] `CurveRoad` shoulder and sidewalk render correctly
+- [ ] `CubicBezierRoad` shoulder and sidewalk render correctly
+- [ ] When `shoulderWidth = 0` and `sidewalkWidth = 0`, no extra elements are rendered (no regression)
+- [ ] `StraightRoadObject` rendering is unchanged (no regression)
+- [ ] All existing tests pass

--- a/docs/shoulder-sidewalk-curved-roads-spec.md
+++ b/docs/shoulder-sidewalk-curved-roads-spec.md
@@ -1,8 +1,8 @@
 # Shoulder & Sidewalk Rendering on Curved Roads — Spec
 
 **Issue:** #195  
-**Status:** Spec — pending implementation  
-**Branch:** TBD (`feat/shoulder-sidewalk-195`)
+**Status:** Implemented  
+**Branch:** `feat/shoulder-sidewalk-195`
 
 ---
 

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -132,8 +132,6 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
   );
 }
 
-// ─── Shared shoulder/sidewalk helper ─────────────────────────────────────────
-
 /**
  * Builds the shoulder and sidewalk Line elements for any curved road type.
  * Returns them in back-to-front order: sidewalk fills, sidewalk edges, shoulders.

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -5,7 +5,7 @@ import type {
   CanvasObject, StraightRoadObject, PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject,
   SignObject, DeviceObject, ZoneObject, ArrowObject, TextObject, MeasureObject, TaperObject, Point,
 } from '../../../types';
-import { angleBetween, dist, sampleBezier, sampleCubicBezier } from '../../../utils';
+import { angleBetween, dist, sampleBezier, sampleCubicBezier, buildOffsetSpine } from '../../../utils';
 import { COLORS, GRID_SIZE } from '../../../features/tcp/constants';
 import { LaneMaskShape, CrosswalkShape, TurnLaneShape } from '../../../shapes/TrafficControlShapes';
 
@@ -134,7 +134,7 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
 
 interface PolylineRoadProps { obj: PolylineRoadObject; isSelected: boolean; }
 export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
-  const { id, points, width, lanes, roadType, smooth } = obj;
+  const { id, points, width, lanes, roadType, smooth, shoulderWidth = 0, sidewalkWidth = 0, sidewalkSide } = obj;
   const tension = smooth ? 0.5 : 0;
   if (!points || points.length < 2) return null;
 
@@ -147,6 +147,9 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
 
   const flat = pts.flatMap((p) => [p.x, p.y]);
   const hw = width / 2;
+  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
+  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
+
   const laneMarkings = [];
   const laneW = width / lanes;
   for (let li = 1; li < lanes; li++) {
@@ -175,8 +178,39 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
     }
   }
 
+  const shoulderOff = hw + shoulderWidth / 2;
+  const shoulderLines = shoulderWidth > 0 ? [
+    <Line key={`${id}-sl`} points={buildOffsetSpine(pts, shoulderOff)}
+      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+    <Line key={`${id}-sr`} points={buildOffsetSpine(pts, -shoulderOff)}
+      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+  ] : [];
+
+  const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2;
+  const sidewalkLines: React.ReactElement[] = [];
+  if (sidewalkWidth > 0 && sidewalkSide) {
+    if (showLeft) {
+      sidewalkLines.push(
+        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(pts, swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(pts, swOff + sidewalkWidth / 2)}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+    if (showRight) {
+      sidewalkLines.push(
+        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(pts, -swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(pts, -(swOff + sidewalkWidth / 2))}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+  }
+
   return (
     <Group listening={false}>
+      {sidewalkLines}
+      {shoulderLines}
       <Line points={flat} stroke="#444" strokeWidth={width + 4} lineCap="round" lineJoin="round" tension={tension} />
       <Line points={flat} stroke={COLORS.roadLineWhite} strokeWidth={width} lineCap="round" lineJoin="round" tension={tension} />
       <Line points={flat} stroke={COLORS.road} strokeWidth={width - 4} lineCap="round" lineJoin="round" tension={tension} />
@@ -193,13 +227,16 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
 
 interface CurveRoadProps { obj: CurveRoadObject; isSelected: boolean; }
 export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
-  const { id, points, width, lanes, roadType } = obj;
+  const { id, points, width, lanes, roadType, shoulderWidth = 0, sidewalkWidth = 0, sidewalkSide } = obj;
   if (!points || points.length < 3) return null;
   const [p0, p1, p2] = points;
 
   const spine = sampleBezier(p0, p1, p2, 32);
   const flat = spine.flatMap((p) => [p.x, p.y]);
   const hw = width / 2;
+  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
+  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
+
   const laneMarkings = [];
   const laneW = width / lanes;
   for (let li = 1; li < lanes; li++) {
@@ -228,8 +265,39 @@ export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
     }
   }
 
+  const shoulderOff = hw + shoulderWidth / 2;
+  const shoulderLines = shoulderWidth > 0 ? [
+    <Line key={`${id}-sl`} points={buildOffsetSpine(spine, shoulderOff)}
+      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+    <Line key={`${id}-sr`} points={buildOffsetSpine(spine, -shoulderOff)}
+      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+  ] : [];
+
+  const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2;
+  const sidewalkLines: React.ReactElement[] = [];
+  if (sidewalkWidth > 0 && sidewalkSide) {
+    if (showLeft) {
+      sidewalkLines.push(
+        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(spine, swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(spine, swOff + sidewalkWidth / 2)}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+    if (showRight) {
+      sidewalkLines.push(
+        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(spine, -swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(spine, -(swOff + sidewalkWidth / 2))}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+  }
+
   return (
     <Group listening={false}>
+      {sidewalkLines}
+      {shoulderLines}
       <Line points={flat} stroke="#444" strokeWidth={width + 4} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.roadLineWhite} strokeWidth={width} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.road} strokeWidth={width - 4} lineCap="round" lineJoin="round" tension={0} />
@@ -247,13 +315,16 @@ export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
 
 interface CubicBezierRoadProps { obj: CubicBezierRoadObject; isSelected: boolean; }
 export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
-  const { id, points, width, lanes, roadType } = obj;
+  const { id, points, width, lanes, roadType, shoulderWidth = 0, sidewalkWidth = 0, sidewalkSide } = obj;
   if (!points || points.length < 4) return null;
   const [p0, p1, p2, p3] = points;
 
   const spine = sampleCubicBezier(p0, p1, p2, p3, 32);
   const flat = spine.flatMap((p) => [p.x, p.y]);
   const hw = width / 2;
+  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
+  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
+
   const laneMarkings = [];
   const laneW = width / lanes;
   for (let li = 1; li < lanes; li++) {
@@ -282,8 +353,39 @@ export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
     }
   }
 
+  const shoulderOff = hw + shoulderWidth / 2;
+  const shoulderLines = shoulderWidth > 0 ? [
+    <Line key={`${id}-sl`} points={buildOffsetSpine(spine, shoulderOff)}
+      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+    <Line key={`${id}-sr`} points={buildOffsetSpine(spine, -shoulderOff)}
+      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+  ] : [];
+
+  const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2;
+  const sidewalkLines: React.ReactElement[] = [];
+  if (sidewalkWidth > 0 && sidewalkSide) {
+    if (showLeft) {
+      sidewalkLines.push(
+        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(spine, swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(spine, swOff + sidewalkWidth / 2)}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+    if (showRight) {
+      sidewalkLines.push(
+        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(spine, -swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(spine, -(swOff + sidewalkWidth / 2))}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+  }
+
   return (
     <Group listening={false}>
+      {sidewalkLines}
+      {shoulderLines}
       <Line points={flat} stroke="#444" strokeWidth={width + 4} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.roadLineWhite} strokeWidth={width} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.road} strokeWidth={width - 4} lineCap="round" lineJoin="round" tension={0} />

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -132,6 +132,59 @@ export function RoadSegment({ obj, isSelected }: RoadSegmentProps) {
   );
 }
 
+// ─── Shared shoulder/sidewalk helper ─────────────────────────────────────────
+
+/**
+ * Builds the shoulder and sidewalk Line elements for any curved road type.
+ * Returns them in back-to-front order: sidewalk fills, sidewalk edges, shoulders.
+ * Uses the same offsets and colors as StraightRoad.
+ */
+function buildShoulderSidewalkLines(
+  id: string,
+  spine: Point[],
+  hw: number,
+  shoulderWidth: number,
+  sidewalkWidth: number,
+  sidewalkSide?: 'left' | 'right' | 'both',
+): React.ReactElement[] {
+  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
+  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
+  const sidewalkLines: React.ReactElement[] = [];
+  const shoulderLines: React.ReactElement[] = [];
+
+  if (sidewalkWidth > 0 && sidewalkSide) {
+    const swOff = hw + shoulderWidth + sidewalkWidth / 2;
+    if (showLeft) {
+      sidewalkLines.push(
+        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(spine, swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(spine, swOff + sidewalkWidth / 2)}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+    if (showRight) {
+      sidewalkLines.push(
+        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(spine, -swOff)}
+          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
+        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(spine, -(swOff + sidewalkWidth / 2))}
+          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
+      );
+    }
+  }
+
+  if (shoulderWidth > 0) {
+    const shoulderOff = hw + shoulderWidth / 2;
+    shoulderLines.push(
+      <Line key={`${id}-sl`} points={buildOffsetSpine(spine, shoulderOff)}
+        stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+      <Line key={`${id}-sr`} points={buildOffsetSpine(spine, -shoulderOff)}
+        stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
+    );
+  }
+
+  return [...sidewalkLines, ...shoulderLines];
+}
+
 interface PolylineRoadProps { obj: PolylineRoadObject; isSelected: boolean; }
 export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
   const { id, points, width, lanes, roadType, smooth, shoulderWidth = 0, sidewalkWidth = 0, sidewalkSide } = obj;
@@ -147,8 +200,6 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
 
   const flat = pts.flatMap((p) => [p.x, p.y]);
   const hw = width / 2;
-  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
-  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
 
   const laneMarkings = [];
   const laneW = width / lanes;
@@ -178,39 +229,11 @@ export function PolylineRoad({ obj, isSelected }: PolylineRoadProps) {
     }
   }
 
-  const shoulderOff = hw + shoulderWidth / 2;
-  const shoulderLines = shoulderWidth > 0 ? [
-    <Line key={`${id}-sl`} points={buildOffsetSpine(pts, shoulderOff)}
-      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
-    <Line key={`${id}-sr`} points={buildOffsetSpine(pts, -shoulderOff)}
-      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
-  ] : [];
-
-  const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2;
-  const sidewalkLines: React.ReactElement[] = [];
-  if (sidewalkWidth > 0 && sidewalkSide) {
-    if (showLeft) {
-      sidewalkLines.push(
-        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(pts, swOff)}
-          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
-        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(pts, swOff + sidewalkWidth / 2)}
-          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
-      );
-    }
-    if (showRight) {
-      sidewalkLines.push(
-        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(pts, -swOff)}
-          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
-        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(pts, -(swOff + sidewalkWidth / 2))}
-          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
-      );
-    }
-  }
+  const extraLines = buildShoulderSidewalkLines(id, pts, hw, shoulderWidth, sidewalkWidth, sidewalkSide);
 
   return (
     <Group listening={false}>
-      {sidewalkLines}
-      {shoulderLines}
+      {extraLines}
       <Line points={flat} stroke="#444" strokeWidth={width + 4} lineCap="round" lineJoin="round" tension={tension} />
       <Line points={flat} stroke={COLORS.roadLineWhite} strokeWidth={width} lineCap="round" lineJoin="round" tension={tension} />
       <Line points={flat} stroke={COLORS.road} strokeWidth={width - 4} lineCap="round" lineJoin="round" tension={tension} />
@@ -234,8 +257,6 @@ export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
   const spine = sampleBezier(p0, p1, p2, 32);
   const flat = spine.flatMap((p) => [p.x, p.y]);
   const hw = width / 2;
-  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
-  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
 
   const laneMarkings = [];
   const laneW = width / lanes;
@@ -265,39 +286,11 @@ export function CurveRoad({ obj, isSelected }: CurveRoadProps) {
     }
   }
 
-  const shoulderOff = hw + shoulderWidth / 2;
-  const shoulderLines = shoulderWidth > 0 ? [
-    <Line key={`${id}-sl`} points={buildOffsetSpine(spine, shoulderOff)}
-      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
-    <Line key={`${id}-sr`} points={buildOffsetSpine(spine, -shoulderOff)}
-      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
-  ] : [];
-
-  const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2;
-  const sidewalkLines: React.ReactElement[] = [];
-  if (sidewalkWidth > 0 && sidewalkSide) {
-    if (showLeft) {
-      sidewalkLines.push(
-        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(spine, swOff)}
-          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
-        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(spine, swOff + sidewalkWidth / 2)}
-          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
-      );
-    }
-    if (showRight) {
-      sidewalkLines.push(
-        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(spine, -swOff)}
-          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
-        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(spine, -(swOff + sidewalkWidth / 2))}
-          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
-      );
-    }
-  }
+  const extraLines = buildShoulderSidewalkLines(id, spine, hw, shoulderWidth, sidewalkWidth, sidewalkSide);
 
   return (
     <Group listening={false}>
-      {sidewalkLines}
-      {shoulderLines}
+      {extraLines}
       <Line points={flat} stroke="#444" strokeWidth={width + 4} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.roadLineWhite} strokeWidth={width} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.road} strokeWidth={width - 4} lineCap="round" lineJoin="round" tension={0} />
@@ -322,8 +315,6 @@ export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
   const spine = sampleCubicBezier(p0, p1, p2, p3, 32);
   const flat = spine.flatMap((p) => [p.x, p.y]);
   const hw = width / 2;
-  const showLeft  = sidewalkSide === 'both' || sidewalkSide === 'left';
-  const showRight = sidewalkSide === 'both' || sidewalkSide === 'right';
 
   const laneMarkings = [];
   const laneW = width / lanes;
@@ -353,39 +344,11 @@ export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
     }
   }
 
-  const shoulderOff = hw + shoulderWidth / 2;
-  const shoulderLines = shoulderWidth > 0 ? [
-    <Line key={`${id}-sl`} points={buildOffsetSpine(spine, shoulderOff)}
-      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
-    <Line key={`${id}-sr`} points={buildOffsetSpine(spine, -shoulderOff)}
-      stroke="rgba(80,90,110,0.8)" strokeWidth={shoulderWidth} lineCap="round" lineJoin="round" listening={false} />,
-  ] : [];
-
-  const swOff = hw + (shoulderWidth > 0 ? shoulderWidth : 0) + sidewalkWidth / 2;
-  const sidewalkLines: React.ReactElement[] = [];
-  if (sidewalkWidth > 0 && sidewalkSide) {
-    if (showLeft) {
-      sidewalkLines.push(
-        <Line key={`${id}-swl-fill`} points={buildOffsetSpine(spine, swOff)}
-          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
-        <Line key={`${id}-swl-edge`} points={buildOffsetSpine(spine, swOff + sidewalkWidth / 2)}
-          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
-      );
-    }
-    if (showRight) {
-      sidewalkLines.push(
-        <Line key={`${id}-swr-fill`} points={buildOffsetSpine(spine, -swOff)}
-          stroke="rgba(200,195,185,0.6)" strokeWidth={sidewalkWidth} lineCap="round" lineJoin="round" listening={false} />,
-        <Line key={`${id}-swr-edge`} points={buildOffsetSpine(spine, -(swOff + sidewalkWidth / 2))}
-          stroke="rgba(160,155,145,0.8)" strokeWidth={1} lineCap="round" lineJoin="round" listening={false} />,
-      );
-    }
-  }
+  const extraLines = buildShoulderSidewalkLines(id, spine, hw, shoulderWidth, sidewalkWidth, sidewalkSide);
 
   return (
     <Group listening={false}>
-      {sidewalkLines}
-      {shoulderLines}
+      {extraLines}
       <Line points={flat} stroke="#444" strokeWidth={width + 4} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.roadLineWhite} strokeWidth={width} lineCap="round" lineJoin="round" tension={0} />
       <Line points={flat} stroke={COLORS.road} strokeWidth={width - 4} lineCap="round" lineJoin="round" tension={0} />

--- a/my-app/src/test/objectShapes.test.ts
+++ b/my-app/src/test/objectShapes.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for shoulder/sidewalk rendering helpers and ObjectShapes components.
+ *
+ * We test the pure utility (buildOffsetSpine) directly, and verify the rendered
+ * element counts for each road component via React Testing Library.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildOffsetSpine } from '../utils'
+import type { Point } from '../types'
+
+// ─── buildOffsetSpine ─────────────────────────────────────────────────────────
+
+describe('buildOffsetSpine', () => {
+  it('offsets a horizontal segment to the left (positive d)', () => {
+    // Segment going right: (0,0) → (10,0). Left normal is (0,-1).
+    const pts: Point[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }]
+    const result = buildOffsetSpine(pts, 5)
+    // Both points shifted by (nx=0, ny=-1)*5 → y decreases by 5
+    expect(result).toHaveLength(4)
+    expect(result[0]).toBeCloseTo(0)   // x0 unchanged
+    expect(result[1]).toBeCloseTo(-5)  // y0 - 5
+    expect(result[2]).toBeCloseTo(10)  // x1 unchanged
+    expect(result[3]).toBeCloseTo(-5)  // y1 - 5
+  })
+
+  it('offsets a horizontal segment to the right (negative d)', () => {
+    const pts: Point[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }]
+    const result = buildOffsetSpine(pts, -5)
+    expect(result[1]).toBeCloseTo(5)
+    expect(result[3]).toBeCloseTo(5)
+  })
+
+  it('offsets a vertical segment correctly', () => {
+    // Segment going down: (0,0) → (0,10). Left normal is (1,0).
+    const pts: Point[] = [{ x: 0, y: 0 }, { x: 0, y: 10 }]
+    const result = buildOffsetSpine(pts, 5)
+    expect(result[0]).toBeCloseTo(5)   // x0 + 5
+    expect(result[1]).toBeCloseTo(0)   // y0 unchanged
+    expect(result[2]).toBeCloseTo(5)   // x1 + 5
+    expect(result[3]).toBeCloseTo(10)  // y1 unchanged (original = 10)
+  })
+
+  it('handles a three-point polyline and preserves point count', () => {
+    const pts: Point[] = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 20, y: 0 },
+    ]
+    const result = buildOffsetSpine(pts, 3)
+    // 3 points × 2 coords each = 6 numbers
+    expect(result).toHaveLength(6)
+  })
+
+  it('uses the last segment normal for the final point', () => {
+    // Two-point segment going right; final point normal = same as only segment normal
+    const pts: Point[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }]
+    const withD = buildOffsetSpine(pts, 10)
+    // Both y values should be -10
+    expect(withD[1]).toBeCloseTo(-10)
+    expect(withD[3]).toBeCloseTo(-10)
+  })
+
+  it('returns a flat array suitable for Konva Line points', () => {
+    const pts: Point[] = [{ x: 1, y: 2 }, { x: 3, y: 4 }, { x: 5, y: 6 }]
+    const result = buildOffsetSpine(pts, 0)
+    // With d=0, output should match the flat input exactly
+    expect(result).toEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('handles a single point gracefully (no crash)', () => {
+    const pts: Point[] = [{ x: 5, y: 5 }]
+    expect(() => buildOffsetSpine(pts, 10)).not.toThrow()
+  })
+
+  it('produces symmetric left/right offsets of equal magnitude', () => {
+    const pts: Point[] = [{ x: 0, y: 0 }, { x: 100, y: 0 }]
+    const left  = buildOffsetSpine(pts, 20)
+    const right = buildOffsetSpine(pts, -20)
+    // y values should be equal in magnitude, opposite in sign
+    for (let i = 1; i < left.length; i += 2) {
+      expect(left[i]).toBeCloseTo(-right[i])
+    }
+  })
+
+  it('offset magnitude equals d for a straight horizontal spine', () => {
+    const pts: Point[] = [{ x: 0, y: 0 }, { x: 50, y: 0 }, { x: 100, y: 0 }]
+    const d = 7
+    const result = buildOffsetSpine(pts, d)
+    // All y values should be exactly -d (normal is (0,-1) for rightward travel)
+    for (let i = 1; i < result.length; i += 2) {
+      expect(result[i]).toBeCloseTo(-d, 6)
+    }
+  })
+})
+
+// ─── Rendered element counts (component smoke tests) ─────────────────────────
+// These tests use React Testing Library to render the road components and count
+// the Konva Line elements in the output, verifying shoulder/sidewalk elements
+// are present or absent based on the object configuration.
+
+import { render } from '@testing-library/react'
+import React from 'react'
+import { PolylineRoad, CurveRoad, CubicBezierRoad } from '../components/tcp/canvas/ObjectShapes'
+import type { PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject } from '../types'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+// ─── PolylineRoad ─────────────────────────────────────────────────────────────
+
+describe('PolylineRoad — shoulder/sidewalk rendering', () => {
+  const base: PolylineRoadObject = {
+    id: 'pr1',
+    type: 'polyline_road',
+    points: [{ x: 0, y: 0 }, { x: 100, y: 0 }, { x: 200, y: 50 }],
+    width: 40,
+    realWidth: 24,
+    lanes: 2,
+    roadType: '2lane',
+    smooth: false,
+  }
+
+  it('renders without error when shoulderWidth=0 and sidewalkWidth=0', () => {
+    expect(() => render(React.createElement(PolylineRoad, { obj: base, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when shoulderWidth > 0', () => {
+    const obj = { ...base, shoulderWidth: 8 }
+    expect(() => render(React.createElement(PolylineRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when sidewalkWidth > 0 and sidewalkSide=both', () => {
+    const obj = { ...base, sidewalkWidth: 12, sidewalkSide: 'both' as const }
+    expect(() => render(React.createElement(PolylineRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error with shoulder + sidewalk on left only', () => {
+    const obj = { ...base, shoulderWidth: 6, sidewalkWidth: 10, sidewalkSide: 'left' as const }
+    expect(() => render(React.createElement(PolylineRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error with smooth=true', () => {
+    const obj = { ...base, smooth: true, shoulderWidth: 8, sidewalkWidth: 10, sidewalkSide: 'both' as const }
+    expect(() => render(React.createElement(PolylineRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+})
+
+// ─── CurveRoad ────────────────────────────────────────────────────────────────
+
+describe('CurveRoad — shoulder/sidewalk rendering', () => {
+  const base: CurveRoadObject = {
+    id: 'cr1',
+    type: 'curve_road',
+    points: [{ x: 0, y: 0 }, { x: 100, y: 100 }, { x: 200, y: 0 }],
+    width: 40,
+    realWidth: 24,
+    lanes: 2,
+    roadType: '2lane',
+  }
+
+  it('renders without error when shoulderWidth=0 and sidewalkWidth=0', () => {
+    expect(() => render(React.createElement(CurveRoad, { obj: base, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when shoulderWidth > 0', () => {
+    const obj = { ...base, shoulderWidth: 8 }
+    expect(() => render(React.createElement(CurveRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when sidewalkWidth > 0 and sidewalkSide=both', () => {
+    const obj = { ...base, sidewalkWidth: 12, sidewalkSide: 'both' as const }
+    expect(() => render(React.createElement(CurveRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error with shoulder + sidewalk on right only', () => {
+    const obj = { ...base, shoulderWidth: 6, sidewalkWidth: 10, sidewalkSide: 'right' as const }
+    expect(() => render(React.createElement(CurveRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+})
+
+// ─── CubicBezierRoad ──────────────────────────────────────────────────────────
+
+describe('CubicBezierRoad — shoulder/sidewalk rendering', () => {
+  const base: CubicBezierRoadObject = {
+    id: 'cbr1',
+    type: 'cubic_bezier_road',
+    points: [{ x: 0, y: 0 }, { x: 50, y: 100 }, { x: 150, y: 100 }, { x: 200, y: 0 }],
+    width: 40,
+    realWidth: 24,
+    lanes: 2,
+    roadType: '2lane',
+  }
+
+  it('renders without error when shoulderWidth=0 and sidewalkWidth=0', () => {
+    expect(() => render(React.createElement(CubicBezierRoad, { obj: base, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when shoulderWidth > 0', () => {
+    const obj = { ...base, shoulderWidth: 8 }
+    expect(() => render(React.createElement(CubicBezierRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when sidewalkWidth > 0 and sidewalkSide=both', () => {
+    const obj = { ...base, sidewalkWidth: 12, sidewalkSide: 'both' as const }
+    expect(() => render(React.createElement(CubicBezierRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error with shoulder + sidewalk (both sides)', () => {
+    const obj = { ...base, shoulderWidth: 8, sidewalkWidth: 12, sidewalkSide: 'both' as const }
+    expect(() => render(React.createElement(CubicBezierRoad, { obj, isSelected: false }))).not.toThrow()
+  })
+
+  it('renders without error when selected', () => {
+    const obj = { ...base, shoulderWidth: 8, sidewalkWidth: 12, sidewalkSide: 'both' as const }
+    expect(() => render(React.createElement(CubicBezierRoad, { obj, isSelected: true }))).not.toThrow()
+  })
+})

--- a/my-app/src/test/objectShapes.test.ts
+++ b/my-app/src/test/objectShapes.test.ts
@@ -10,33 +10,37 @@ import type { Point } from '../types'
 
 // ─── buildOffsetSpine ─────────────────────────────────────────────────────────
 
+// buildOffsetSpine uses the same normal convention as StraightRoad: (nx,ny) = (-dy/len, dx/len).
+// For a rightward segment (dx>0, dy=0): nx=0, ny=1 → positive d shifts Y downward (south).
+// This matches how StraightRoad's positive-normal side maps to sidewalkSide='left'.
+
 describe('buildOffsetSpine', () => {
-  it('offsets a horizontal segment to the left (positive d)', () => {
-    // Segment going right: (0,0) → (10,0). Left normal is (0,-1).
+  it('offsets a horizontal segment with positive d (ny=+1 direction)', () => {
+    // Segment going right: (0,0) → (10,0). Normal is (0,+1) — downward in Y-down canvas.
     const pts: Point[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }]
     const result = buildOffsetSpine(pts, 5)
-    // Both points shifted by (nx=0, ny=-1)*5 → y decreases by 5
+    // Both points shifted by (nx=0, ny=+1)*5 → y increases by 5
     expect(result).toHaveLength(4)
     expect(result[0]).toBeCloseTo(0)   // x0 unchanged
-    expect(result[1]).toBeCloseTo(-5)  // y0 - 5
+    expect(result[1]).toBeCloseTo(5)   // y0 + 5
     expect(result[2]).toBeCloseTo(10)  // x1 unchanged
-    expect(result[3]).toBeCloseTo(-5)  // y1 - 5
+    expect(result[3]).toBeCloseTo(5)   // y1 + 5
   })
 
-  it('offsets a horizontal segment to the right (negative d)', () => {
+  it('offsets a horizontal segment with negative d (opposite side)', () => {
     const pts: Point[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }]
     const result = buildOffsetSpine(pts, -5)
-    expect(result[1]).toBeCloseTo(5)
-    expect(result[3]).toBeCloseTo(5)
+    expect(result[1]).toBeCloseTo(-5)
+    expect(result[3]).toBeCloseTo(-5)
   })
 
   it('offsets a vertical segment correctly', () => {
-    // Segment going down: (0,0) → (0,10). Left normal is (1,0).
+    // Segment going down: (0,0) → (0,10). Normal is (-1,0) — leftward.
     const pts: Point[] = [{ x: 0, y: 0 }, { x: 0, y: 10 }]
     const result = buildOffsetSpine(pts, 5)
-    expect(result[0]).toBeCloseTo(5)   // x0 + 5
+    expect(result[0]).toBeCloseTo(-5)  // x0 - 5
     expect(result[1]).toBeCloseTo(0)   // y0 unchanged
-    expect(result[2]).toBeCloseTo(5)   // x1 + 5
+    expect(result[2]).toBeCloseTo(-5)  // x1 - 5
     expect(result[3]).toBeCloseTo(10)  // y1 unchanged (original = 10)
   })
 
@@ -52,12 +56,12 @@ describe('buildOffsetSpine', () => {
   })
 
   it('uses the last segment normal for the final point', () => {
-    // Two-point segment going right; final point normal = same as only segment normal
+    // Two-point segment going right; final point uses same segment's normal
     const pts: Point[] = [{ x: 0, y: 0 }, { x: 10, y: 0 }]
     const withD = buildOffsetSpine(pts, 10)
-    // Both y values should be -10
-    expect(withD[1]).toBeCloseTo(-10)
-    expect(withD[3]).toBeCloseTo(-10)
+    // Both y values should be +10 (ny=+1 for rightward segment)
+    expect(withD[1]).toBeCloseTo(10)
+    expect(withD[3]).toBeCloseTo(10)
   })
 
   it('returns a flat array suitable for Konva Line points', () => {
@@ -67,18 +71,19 @@ describe('buildOffsetSpine', () => {
     expect(result).toEqual([1, 2, 3, 4, 5, 6])
   })
 
-  it('handles a single point gracefully (no crash)', () => {
+  it('handles a single point gracefully (no crash, returns point unchanged)', () => {
     const pts: Point[] = [{ x: 5, y: 5 }]
     expect(() => buildOffsetSpine(pts, 10)).not.toThrow()
+    expect(buildOffsetSpine(pts, 10)).toEqual([5, 5])
   })
 
-  it('produces symmetric left/right offsets of equal magnitude', () => {
+  it('produces symmetric offsets of equal magnitude on opposite sides', () => {
     const pts: Point[] = [{ x: 0, y: 0 }, { x: 100, y: 0 }]
-    const left  = buildOffsetSpine(pts, 20)
-    const right = buildOffsetSpine(pts, -20)
+    const pos  = buildOffsetSpine(pts, 20)
+    const neg = buildOffsetSpine(pts, -20)
     // y values should be equal in magnitude, opposite in sign
-    for (let i = 1; i < left.length; i += 2) {
-      expect(left[i]).toBeCloseTo(-right[i])
+    for (let i = 1; i < pos.length; i += 2) {
+      expect(pos[i]).toBeCloseTo(-neg[i])
     }
   })
 
@@ -86,25 +91,22 @@ describe('buildOffsetSpine', () => {
     const pts: Point[] = [{ x: 0, y: 0 }, { x: 50, y: 0 }, { x: 100, y: 0 }]
     const d = 7
     const result = buildOffsetSpine(pts, d)
-    // All y values should be exactly -d (normal is (0,-1) for rightward travel)
+    // ny=+1 for rightward travel → all y values = +d
     for (let i = 1; i < result.length; i += 2) {
-      expect(result[i]).toBeCloseTo(-d, 6)
+      expect(result[i]).toBeCloseTo(d, 6)
     }
   })
 })
 
-// ─── Rendered element counts (component smoke tests) ─────────────────────────
-// These tests use React Testing Library to render the road components and count
-// the Konva Line elements in the output, verifying shoulder/sidewalk elements
-// are present or absent based on the object configuration.
+// ─── Component smoke tests ────────────────────────────────────────────────────
+// react-konva primitives are mocked to render null in the jsdom test env, so
+// these tests only verify that each road component renders without throwing for
+// various shoulder/sidewalk configurations.
 
 import { render } from '@testing-library/react'
 import React from 'react'
 import { PolylineRoad, CurveRoad, CubicBezierRoad } from '../components/tcp/canvas/ObjectShapes'
 import type { PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject } from '../types'
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
 
 // ─── PolylineRoad ─────────────────────────────────────────────────────────────
 

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -162,6 +162,26 @@ export function sampleCubicBezier(p0: Point, p1: Point, p2: Point, p3: Point, n:
   return pts
 }
 
+/**
+ * Build a flat Konva points array offset perpendicular to the polyline by `d` pixels.
+ * Positive `d` is to the left of the direction of travel (canvas +Y-down convention).
+ * Uses the outgoing-segment normal at each point; the final point uses the last
+ * segment's normal. Works for both densely-sampled spines and raw control points.
+ */
+export function buildOffsetSpine(pts: Point[], d: number): number[] {
+  if (pts.length < 2) return pts.flatMap((p) => [p.x + d, p.y])
+  const result: number[] = []
+  for (let i = 0; i < pts.length; i++) {
+    const a = i < pts.length - 1 ? pts[i] : pts[i - 1]
+    const b = i < pts.length - 1 ? pts[i + 1] : pts[i]
+    const dx = b.x - a.x, dy = b.y - a.y
+    const len = Math.sqrt(dx * dx + dy * dy) || 1
+    const nx = dy / len, ny = -dx / len
+    result.push(pts[i].x + nx * d, pts[i].y + ny * d)
+  }
+  return result
+}
+
 export function sampleBezier(p0: Point, p1: Point, p2: Point, n: number): Point[] {
   const pts: Point[] = []
   for (let i = 0; i <= n; i++) {

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -164,19 +164,23 @@ export function sampleCubicBezier(p0: Point, p1: Point, p2: Point, p3: Point, n:
 
 /**
  * Build a flat Konva points array offset perpendicular to the polyline by `d` pixels.
- * Positive `d` is to the left of the direction of travel (canvas +Y-down convention).
+ * Uses the same normal convention as StraightRoad: `(nx, ny) = (-dy/len, dx/len)`,
+ * so positive `d` offsets in the same direction as StraightRoad's positive-normal side
+ * (and `sidewalkSide = 'left'` corresponds to positive `d`).
  * Uses the outgoing-segment normal at each point; the final point uses the last
  * segment's normal. Works for both densely-sampled spines and raw control points.
+ * Returns a flat array of [x0, y0, x1, y1, ...] suitable for Konva Line `points`.
+ * If fewer than 2 points are provided, returns the original points unchanged (no offset).
  */
 export function buildOffsetSpine(pts: Point[], d: number): number[] {
-  if (pts.length < 2) return pts.flatMap((p) => [p.x + d, p.y])
+  if (pts.length < 2) return pts.flatMap((p) => [p.x, p.y])
   const result: number[] = []
   for (let i = 0; i < pts.length; i++) {
     const a = i < pts.length - 1 ? pts[i] : pts[i - 1]
     const b = i < pts.length - 1 ? pts[i + 1] : pts[i]
     const dx = b.x - a.x, dy = b.y - a.y
     const len = Math.sqrt(dx * dx + dy * dy) || 1
-    const nx = dy / len, ny = -dx / len
+    const nx = -dy / len, ny = dx / len
     result.push(pts[i].x + nx * d, pts[i].y + ny * d)
   }
   return result


### PR DESCRIPTION
## Summary

- Add `buildOffsetSpine(pts, d)` utility that shifts any polyline perpendicularly by `d` pixels, using per-segment outgoing normals (positive `d` = left of travel in Y-down canvas convention)
- Update `PolylineRoad`, `CurveRoad`, and `CubicBezierRoad` in `ObjectShapes.tsx` to render shoulder and sidewalk `<Line>` elements using the offset spine, matching the colors/offsets already used by `StraightRoad`
- Add `objectShapes.test.ts`: 8 `buildOffsetSpine` unit tests + 14 component smoke tests

## Closes

Closes #195

## Test plan

- [x] `buildOffsetSpine` unit tested for horizontal, vertical, multi-point, symmetric, and zero-offset cases
- [x] `PolylineRoad` smoke tests: no shoulder, shoulder only, sidewalk only, shoulder+sidewalk (both sides), smooth=true
- [x] `CurveRoad` smoke tests: no shoulder, shoulder only, sidewalk only, shoulder+sidewalk (right only)
- [x] `CubicBezierRoad` smoke tests: no shoulder, shoulder only, sidewalk only, shoulder+sidewalk, selected state
- [x] All 386 existing tests pass (`npx vitest run`)
- [x] TypeScript clean (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for rendering shoulders and sidewalks on polyline and curved road shapes using an offset spine utility.

New Features:
- Render shoulders and sidewalks for PolylineRoad, CurveRoad, and CubicBezierRoad using existing shoulder/sidewalk properties.

Enhancements:
- Introduce a reusable buildOffsetSpine utility to generate offset polylines for road-adjacent elements.

Documentation:
- Add a spec document describing the visual and behavioral requirements for shoulder and sidewalk rendering on curved roads.

Tests:
- Add unit tests for the buildOffsetSpine utility and smoke tests covering shoulder and sidewalk rendering for all curved road components.