### PR TITLE
fix(geocoder): switch from ArcGIS to Nominatim for accurate street-level results

### DIFF
--- a/my-app/src/test/utils.test.ts
+++ b/my-app/src/test/utils.test.ts
@@ -205,19 +205,23 @@ describe('geocodeAddress', () => {
   })
 
   it('returns mapped results on success', async () => {
-    const mockData = {
-      candidates: [
-        { address: '123 Main St', location: { x: -74, y: 40 } },
-      ],
-    }
+    const mockData = [
+      {
+        lat: '40.7128',
+        lon: '-74.0060',
+        display_name: '123 Main St, New York, NY, USA',
+        address: { house_number: '123', road: 'Main St', city: 'New York', state: 'NY' },
+      },
+    ]
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockData),
     }))
     const results = await geocodeAddress('123 Main St')
     expect(results).toHaveLength(1)
-    expect(results[0].lat).toBe('40')
-    expect(results[0].lon).toBe('-74')
+    expect(results[0].lat).toBe('40.7128')
+    expect(results[0].lon).toBe('-74.0060')
+    expect(results[0].address.road).toBe('Main St')
   })
 
   it('returns empty array when fetch throws', async () => {

--- a/my-app/src/test/utils.test.ts
+++ b/my-app/src/test/utils.test.ts
@@ -235,6 +235,15 @@ describe('geocodeAddress', () => {
     const results = await geocodeAddress('anything')
     expect(results).toEqual([])
   })
+
+  it('returns empty array when response is not an array', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ error: 'Unable to geocode' }),
+    }))
+    const results = await geocodeAddress('anything')
+    expect(results).toEqual([])
+  })
 })
 
 // ─── calcTaperLength ──────────────────────────────────────────────────────────

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -279,6 +279,7 @@ export async function geocodeAddress(query: string): Promise<GeocodeResult[]> {
   try {
     const response = await fetch(
       `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=5&addressdetails=1`,
+      { headers: { 'User-Agent': 'TrafficControlPlanner/1.0 (https://tcplanpro.com)' } },
     )
     if (!response.ok) return []
     const data = await response.json()

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -278,24 +278,20 @@ export function buildTileUrl(template: string, z: number, x: number, y: number):
 export async function geocodeAddress(query: string): Promise<GeocodeResult[]> {
   try {
     const response = await fetch(
-      `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?f=json&singleLine=${encodeURIComponent(query)}&maxLocations=5`,
+      `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=5&addressdetails=1`,
     )
     if (!response.ok) return []
     const data = await response.json()
-    const candidates = Array.isArray(data?.candidates) ? data.candidates : []
-    return candidates.map(
-      (
-        c: Record<string, unknown> & {
-          location?: { x?: number; y?: number }
-          address?: string
-        },
-      ) => ({
-        lat: String(c?.location?.y ?? ''),
-        lon: String(c?.location?.x ?? ''),
-        display_name: c?.address || '',
-        address: { road: c?.address || '' },
-      }),
-    )
+    if (!Array.isArray(data)) return []
+    return (data as Array<Record<string, unknown>>).map((item) => {
+      const addr = (item.address ?? {}) as GeocodeAddress
+      return {
+        lat: String(item.lat ?? ''),
+        lon: String(item.lon ?? ''),
+        display_name: String(item.display_name ?? ''),
+        address: addr,
+      }
+    })
   } catch {
     return []
   }

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -1,5 +1,5 @@
 import type {
-  CanvasObject, GeocodeResult, MapCenter, Point, SnapResult,
+  CanvasObject, GeocodeResult, GeocodeAddress, MapCenter, Point, SnapResult,
   SignObject, DeviceObject, ZoneObject, TextObject, TaperObject, TurnLaneObject,
   StraightRoadObject, PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject, ArrowObject, MeasureObject, LaneMaskObject, CrosswalkObject,
 } from './types'


### PR DESCRIPTION
## Summary

- Replaces the ArcGIS unauthenticated geocoder with Nominatim (OSM), which returns precise street-level coordinates
- ArcGIS was returning locations several miles off for specific addresses (e.g. "1906 Miller Ave, Belmont, CA")
- Nominatim's response shape (`lat`/`lon` strings + structured `address` object) already matches the `GeocodeAddress` type — no adapter shim needed
- Updates the corresponding unit test mock to use Nominatim response shape; all 48 utils tests pass
- Closes #265 (supersedes)

## Test plan

- [ ] Search "1906 Miller Ave, Belmont, CA 94002" — map should center on the correct block
- [ ] Verify search suggestions show formatted `street, city, state` labels
- [ ] Verify empty/bad searches still return empty results gracefully
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Switch the geocoding utility from ArcGIS to Nominatim and adjust tests to match the new response format.

Bug Fixes:
- Ensure geocoding returns accurate street-level coordinates by using Nominatim instead of the less precise ArcGIS endpoint.

Enhancements:
- Normalize the geocode result mapping to leverage Nominatim's native lat/lon and structured address fields.

Tests:
- Update geocodeAddress unit test mocks and assertions to reflect the Nominatim response shape and verify structured address data.