### PR TITLE
fix(test): address test quality issues #246, #248, #252

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -138,7 +138,8 @@ def test_rate_limit_window_allows_after_expiry(monkeypatch, valid_issue):
     # Clear any state from previous tests for this IP.
     main_module._ip_submissions.pop("192.0.2.55", None)
     # Simulate 3 requests at t=1000,1001,1002 then a 4th at t=4605 (>1h later).
-    # The 4th should be allowed (returns 503 upstream error, not 429 rate-limited).
+    # The 4th should be allowed past the rate limiter (returns 503 because GITHUB_TOKEN
+    # is unset, not 429 which would mean still rate-limited).
     # Use itertools.chain so extra calls (middleware, logging) don't exhaust the
     # iterator and raise StopIteration → RuntimeError inside an async context.
     import itertools

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -132,12 +132,21 @@ def test_rate_limit_scoped_per_ip(monkeypatch, valid_issue):
 
 def test_rate_limit_window_allows_after_expiry(monkeypatch, valid_issue):
     """Old hits outside the 1-hour window should no longer count."""
+    import main as main_module
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    headers = {"x-forwarded-for": "192.0.2.44"}
-    # Seed three old hits; at time 4605 they're all outside the rolling window.
-    with patch("main.time.time", return_value=4605):
-        import main
-        main._ip_submissions["192.0.2.44"] = [1000, 1001, 1002]
+    headers = {"x-forwarded-for": "192.0.2.55"}
+    # Clear any state from previous tests for this IP.
+    main_module._ip_submissions.pop("192.0.2.55", None)
+    # Simulate 3 requests at t=1000,1001,1002 then a 4th at t=4605 (>1h later).
+    # The 4th should be allowed (returns 503 upstream error, not 429 rate-limited).
+    # Use itertools.chain so extra calls (middleware, logging) don't exhaust the
+    # iterator and raise StopIteration → RuntimeError inside an async context.
+    import itertools
+    times_iter = itertools.chain([1000, 1001, 1002, 4605], itertools.repeat(4605))
+
+    with patch("main.time.time", side_effect=lambda: next(times_iter)):
+        for _ in range(3):
+            client.post("/create-issue", json=valid_issue, headers=headers)
         res = client.post("/create-issue", json=valid_issue, headers=headers)
         assert res.status_code == 503
 

--- a/my-app/src/hooks/useAutosave.test.ts
+++ b/my-app/src/hooks/useAutosave.test.ts
@@ -73,9 +73,11 @@ describe('useAutosave', () => {
 
   it('reports storage failures and clears the error after a later successful write', async () => {
     const setItemSpy = vi.spyOn(window.localStorage, 'setItem')
-    setItemSpy.mockImplementationOnce(() => {
-      throw new Error('quota exceeded')
-    })
+    // StrictMode double-invokes effects; mock must throw on both invocations
+    // so autosaveError is still set when we assert it.
+    setItemSpy
+      .mockImplementationOnce(() => { throw new Error('quota exceeded') })
+      .mockImplementationOnce(() => { throw new Error('quota exceeded') })
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     const { result, rerender } = renderHook(
@@ -85,6 +87,10 @@ describe('useAutosave', () => {
 
     await waitFor(() => {
       expect(warnSpy).toHaveBeenCalledWith('[TCP] Auto-save failed:', 'quota exceeded')
+    })
+
+    await waitFor(() => {
+      expect(result.current.autosaveError).toBe('quota exceeded')
     })
 
     rerender({ objects: makeObjects(['a', 'b']) })

--- a/my-app/src/hooks/useCanvasEvents.test.ts
+++ b/my-app/src/hooks/useCanvasEvents.test.ts
@@ -163,6 +163,7 @@ describe('useCanvasEvents null tool selections', () => {
     expect(mocks.setObjects).not.toHaveBeenCalled()
     expect(mocks.pushHistory).not.toHaveBeenCalled()
     expect(mocks.setSelected).not.toHaveBeenCalled()
+    expect(track).not.toHaveBeenCalled()
   })
 
   it('creates a straight road on mouse up when drag distance is sufficient', () => {


### PR DESCRIPTION
## Summary

Three test quality fixes — no production code changes.

**#246 — `useAutosave` storage-failure test missing `autosaveError` assertion**
Added `await waitFor(() => expect(result.current.autosaveError).toBe('quota exceeded'))` before the recovery rerender. Had to mock `setItem` to throw twice because `@testing-library/react` v16 wraps `renderHook` in StrictMode, which double-invokes effects.

**#248 — Rate-limit window-expiry test seeded state via direct mutation**
Replaced `main._ip_submissions["192.0.2.44"] = [...]` with 3 real POST requests at `t=1000,1001,1002` followed by a 4th at `t=4605`. Uses `itertools.chain(..., itertools.repeat(4605))` so extra `time.time()` calls from middleware don't exhaust the iterator and trigger `StopIteration → RuntimeError` in async context.

**#252 — Device-null guard test missing `expect(track).not.toHaveBeenCalled()`**
Added the missing assertion to match the equivalent sign-null test.

## Test plan

- [x] 392/392 frontend tests passing
- [x] 58/58 backend tests passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve reliability and correctness of frontend and backend tests without changing production behavior.

Bug Fixes:
- Ensure the autosave hook test reliably asserts that storage failures set and later clear the autosave error state under StrictMode double invocation.
- Correct the rate-limit window expiry test to exercise the API via real timed requests instead of mutating internal state directly, preventing iterator exhaustion errors.
- Tighten the canvas events device-null guard test by asserting that tracking is not invoked when no device is selected.

Tests:
- Refine autosave error-handling tests to account for StrictMode’s double effect invocation and explicitly verify the error state.
- Rework the rate-limiting window expiry test to simulate realistic request timing using a patched time iterator and isolated IP state.
- Enhance the canvas event handling tests to cover telemetry behavior when active tool/device is null.