### PR TITLE
feat(taper): auto-channelization — MUTCD work zone from speed + lane config

### DIFF
--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -6,11 +6,10 @@ import type {
   SignObject, DeviceObject, ZoneObject, ArrowObject, TextObject, MeasureObject, TaperObject, Point,
 } from '../../../types';
 import { angleBetween, dist, sampleBezier, sampleCubicBezier, buildOffsetSpine } from '../../../utils';
-import { COLORS, GRID_SIZE } from '../../../features/tcp/constants';
+import { COLORS, GRID_SIZE, TAPER_SCALE } from '../../../features/tcp/constants';
 import { LaneMaskShape, CrosswalkShape, TurnLaneShape } from '../../../shapes/TrafficControlShapes';
 
-// px per foot — chosen to match road scale (2-lane road = 22 ft realWidth ≈ 80 px → ~3.6 px/ft)
-export const TAPER_SCALE = 3;
+export { TAPER_SCALE };
 
 interface GridLinesProps { offset: Point; zoom: number; canvasSize: { w: number; h: number }; }
 export function GridLines({ offset, zoom, canvasSize }: GridLinesProps) {

--- a/my-app/src/components/tcp/panels/PropertyPanel.tsx
+++ b/my-app/src/components/tcp/panels/PropertyPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type {
   CanvasObject, TaperObject, TurnLaneObject, LaneMaskObject, CrosswalkObject, PlanMeta,
 } from '../../../types';
@@ -13,9 +14,11 @@ interface PropertyPanelProps {
   onReorder: (id: string, dir: "front" | "forward" | "backward" | "back") => void;
   planMeta: PlanMeta;
   onUpdateMeta: (meta: PlanMeta) => void;
+  onAutoChannelize: (taperId: string, workZoneLengthFt: number) => void;
 }
 
-export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder, planMeta, onUpdateMeta }: PropertyPanelProps) {
+export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder, planMeta, onUpdateMeta, onAutoChannelize }: PropertyPanelProps) {
+  const [workZoneLength, setWorkZoneLength] = useState(500);
   if (!selected) {
     return (
       <div style={{ padding: 12 }}>
@@ -125,6 +128,23 @@ export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder
                 style={{ width: "100%", accentColor: COLORS.accent }}
                 onChange={(e) => onUpdate(t.id, { rotation: +e.target.value })} />
             </label>
+            <div style={{ borderTop: `1px solid ${COLORS.panelBorder}`, paddingTop: 8, marginTop: 4 }}>
+              {sectionTitle("Auto-Channelize")}
+              <label style={{ fontSize: 11, color: COLORS.textMuted }}>
+                Work Zone Length: {workZoneLength} ft
+                <input type="range" min={100} max={5000} step={50} value={workZoneLength}
+                  style={{ width: "100%", accentColor: COLORS.accent }}
+                  onChange={(e) => setWorkZoneLength(+e.target.value)} />
+              </label>
+              <div style={{ fontSize: 10, color: COLORS.textDim, marginBottom: 6 }}>
+                Places MUTCD Table 6H-3 advance warning signs + downstream taper
+              </div>
+              <button type="button"
+                style={{ ...panelBtnStyle, background: COLORS.accent, color: '#fff', width: '100%' }}
+                onClick={() => onAutoChannelize(t.id, workZoneLength)}>
+                Auto-Channelize
+              </button>
+            </div>
           </div>
         );
       })()}

--- a/my-app/src/features/tcp/constants.ts
+++ b/my-app/src/features/tcp/constants.ts
@@ -5,6 +5,12 @@ export const MAX_ZOOM = 5;
 export const SNAP_RADIUS = 14;   // screen-pixels for endpoint snap
 export const STATUS_BAR_H = 28;  // height of the bottom status bar in px
 
+// ─── Taper / channelization constants ────────────────────────────────────────
+/** Canvas pixels per real-world foot for taper geometry. */
+export const TAPER_SCALE = 3;
+/** Lateral clearance (px) from road edge to placed advance warning signs. */
+export const SIGN_LATERAL_CLEARANCE_PX = 30;
+
 // ─── Color palette ────────────────────────────────────────────────────────────
 export const COLORS = {
   bg: "#0f1117",

--- a/my-app/src/hooks/useCanvasEvents.ts
+++ b/my-app/src/hooks/useCanvasEvents.ts
@@ -11,12 +11,9 @@ import {
   uid, dist, geoRoadWidthPx, snapToEndpoint, sampleBezier, sampleCubicBezier,
   distToPolyline, isPointObject, isLineObject, isMultiPointRoad, calcTaperLength,
 } from '../utils';
-import { SNAP_RADIUS, MIN_ZOOM, MAX_ZOOM } from '../features/tcp/constants';
+import { SNAP_RADIUS, MIN_ZOOM, MAX_ZOOM, TAPER_SCALE } from '../features/tcp/constants';
 import { createIntersectionRoads } from '../features/tcp/planUtils';
 import { track } from '../analytics';
-
-// px-per-foot scale for taper hit-radius calculation — matches TaperShape in ObjectShapes.tsx
-const TAPER_SCALE = 3;
 import { latLonToPixel, pixelToLatLon } from '../components/tcp/canvas/MiniMap';
 
 interface CanvasEventsProps {

--- a/my-app/src/test/utils.test.ts
+++ b/my-app/src/test/utils.test.ts
@@ -12,8 +12,9 @@ import {
   geocodeAddress,
   calcTaperLength,
   cloneObject,
+  autoChannelize,
 } from '../utils'
-import type { CanvasObject, GeocodeResult } from '../types'
+import type { CanvasObject, GeocodeResult, TaperObject, SignObject } from '../types'
 
 // ─── dist ─────────────────────────────────────────────────────────────────────
 describe('dist', () => {
@@ -388,5 +389,79 @@ describe('sampleCubicBezier', () => {
     const pts = sampleCubicBezier(a, b, c, d, 2)
     expect(pts[1].y).toBeCloseTo(0)
     expect(pts[1].x).toBeCloseTo(50)
+  })
+})
+
+// ─── autoChannelize ───────────────────────────────────────────────────────────
+describe('autoChannelize', () => {
+  function makeTaper(overrides: Partial<TaperObject> = {}): TaperObject {
+    return {
+      id: 'taper-1',
+      type: 'taper',
+      x: 500,
+      y: 300,
+      rotation: 0,
+      laneWidth: 12,
+      speed: 45,
+      taperLength: 405,
+      manualLength: false,
+      numLanes: 1,
+      ...overrides,
+    }
+  }
+
+  it('returns 4 objects: 3 advance warning signs + 1 downstream taper', () => {
+    const result = autoChannelize(makeTaper(), 500)
+    expect(result).toHaveLength(4)
+    expect(result.filter((o) => o.type === 'sign')).toHaveLength(3)
+    expect(result.filter((o) => o.type === 'taper')).toHaveLength(1)
+  })
+
+  it('places signs with unique ids', () => {
+    const result = autoChannelize(makeTaper(), 500)
+    const ids = result.map((o) => o.id)
+    expect(new Set(ids).size).toBe(4)
+  })
+
+  it('places advance signs upstream (lower x) of the taper for rotation=0', () => {
+    const taper = makeTaper({ x: 500, y: 300, rotation: 0 })
+    const signs = autoChannelize(taper, 500).filter((o) => o.type === 'sign') as SignObject[]
+    for (const sign of signs) {
+      expect(sign.x).toBeLessThan(taper.x)
+    }
+  })
+
+  it('spaces signs at 200 ft apart (3 px/ft) for 45 mph', () => {
+    // 45 mph → 200 ft spacing → 600 px
+    const taper = makeTaper({ x: 1000, y: 0, rotation: 0, speed: 45 })
+    const signs = autoChannelize(taper, 500)
+      .filter((o) => o.type === 'sign') as SignObject[]
+    // sorted nearest to farthest
+    const xs = signs.map((s) => s.x).sort((a, b) => b - a)
+    expect(xs[0]).toBeCloseTo(1000 - 600)
+    expect(xs[1]).toBeCloseTo(1000 - 1200)
+    expect(xs[2]).toBeCloseTo(1000 - 1800)
+  })
+
+  it('places downstream taper to the right of the work zone for rotation=0', () => {
+    const taper = makeTaper({ x: 500, y: 300, rotation: 0, taperLength: 405 })
+    const ds = autoChannelize(taper, 500).find((o) => o.type === 'taper') as TaperObject
+    // Downstream taper should be to the right of the merge taper
+    expect(ds.x).toBeGreaterThan(taper.x)
+  })
+
+  it('downstream taper rotation is 180° offset from merge taper', () => {
+    const taper = makeTaper({ rotation: 45 })
+    const ds = autoChannelize(taper, 500).find((o) => o.type === 'taper') as TaperObject
+    expect(ds.rotation).toBe(225)
+  })
+
+  it('uses 100 ft spacing for speed ≤ 35 mph', () => {
+    const taper = makeTaper({ x: 1000, y: 0, rotation: 0, speed: 30 })
+    const signs = autoChannelize(taper, 500)
+      .filter((o) => o.type === 'sign') as SignObject[]
+    // 100 ft × 3 px/ft = 300 px
+    const xs = signs.map((s) => s.x).sort((a, b) => b - a)
+    expect(xs[0]).toBeCloseTo(1000 - 300)
   })
 })

--- a/my-app/src/test/utils.test.ts
+++ b/my-app/src/test/utils.test.ts
@@ -423,6 +423,16 @@ describe('autoChannelize', () => {
     expect(new Set(ids).size).toBe(4)
   })
 
+  it('places advance signs in MUTCD sequence: ONE LANE RD → ROAD WORK → WORK AHEAD', () => {
+    const taper = makeTaper({ x: 1000, y: 0, rotation: 0 })
+    const signs = autoChannelize(taper, 500).filter((o) => o.type === 'sign') as SignObject[]
+    // Sorted nearest to farthest from taper
+    const sorted = [...signs].sort((a, b) => b.x - a.x)
+    expect(sorted.map((s) => s.signData.label)).toEqual(['ONE LANE RD', 'ROAD WORK', 'WORK AHEAD'])
+    expect(sorted.map((s) => s.signData.shape)).toEqual(['rect', 'diamond', 'diamond'])
+    expect(sorted.map((s) => s.signData.mutcd)).toEqual(['W20-4a', 'W20-1', 'W20-1'])
+  })
+
   it('places advance signs upstream (lower x) of the taper for rotation=0', () => {
     const taper = makeTaper({ x: 500, y: 300, rotation: 0 })
     const signs = autoChannelize(taper, 500).filter((o) => o.type === 'sign') as SignObject[]
@@ -431,37 +441,54 @@ describe('autoChannelize', () => {
     }
   })
 
-  it('spaces signs at 200 ft apart (3 px/ft) for 45 mph', () => {
-    // 45 mph → 200 ft spacing → 600 px
-    const taper = makeTaper({ x: 1000, y: 0, rotation: 0, speed: 45 })
-    const signs = autoChannelize(taper, 500)
-      .filter((o) => o.type === 'sign') as SignObject[]
-    // sorted nearest to farthest
+  it('places advance signs upstream of the taper for rotation=90°', () => {
+    // rotation=90 (clockwise) → forward is downward (+y), upstream is upward (-y)
+    // lateral offset (local +y) maps to world leftward (-x)
+    const taper = makeTaper({ x: 500, y: 500, rotation: 90 })
+    const signs = autoChannelize(taper, 500).filter((o) => o.type === 'sign') as SignObject[]
+    for (const sign of signs) {
+      expect(sign.y).toBeLessThan(taper.y) // upstream = above
+      expect(sign.x).toBeLessThan(taper.x) // right-of-road = leftward for downward travel
+    }
+  })
+
+  it.each([
+    [30, 100],
+    [35, 100],
+    [36, 200],
+    [45, 200],
+    [46, 350],
+    [55, 350],
+    [56, 500],
+    [65, 500],
+    [66, 600],
+    [75, 600],
+  ])('uses %i mph → %i ft MUTCD sign spacing', (speed, expectedFt) => {
+    const taper = makeTaper({ x: 3000, y: 0, rotation: 0, speed })
+    const signs = autoChannelize(taper, 500).filter((o) => o.type === 'sign') as SignObject[]
     const xs = signs.map((s) => s.x).sort((a, b) => b - a)
-    expect(xs[0]).toBeCloseTo(1000 - 600)
-    expect(xs[1]).toBeCloseTo(1000 - 1200)
-    expect(xs[2]).toBeCloseTo(1000 - 1800)
+    // Gap between consecutive signs should equal spacingFt × 3 px/ft
+    expect(xs[0] - xs[1]).toBeCloseTo(expectedFt * 3)
+    expect(xs[1] - xs[2]).toBeCloseTo(expectedFt * 3)
   })
 
   it('places downstream taper to the right of the work zone for rotation=0', () => {
     const taper = makeTaper({ x: 500, y: 300, rotation: 0, taperLength: 405 })
     const ds = autoChannelize(taper, 500).find((o) => o.type === 'taper') as TaperObject
-    // Downstream taper should be to the right of the merge taper
     expect(ds.x).toBeGreaterThan(taper.x)
+    expect(ds.taperLength).toBeCloseTo(calcTaperLength(taper.speed, taper.laneWidth, taper.numLanes))
+    expect(ds.laneWidth).toBe(taper.laneWidth)
+    expect(ds.numLanes).toBe(taper.numLanes)
+    expect(ds.manualLength).toBe(false)
   })
 
   it('downstream taper rotation is 180° offset from merge taper', () => {
     const taper = makeTaper({ rotation: 45 })
     const ds = autoChannelize(taper, 500).find((o) => o.type === 'taper') as TaperObject
     expect(ds.rotation).toBe(225)
-  })
-
-  it('uses 100 ft spacing for speed ≤ 35 mph', () => {
-    const taper = makeTaper({ x: 1000, y: 0, rotation: 0, speed: 30 })
-    const signs = autoChannelize(taper, 500)
-      .filter((o) => o.type === 'sign') as SignObject[]
-    // 100 ft × 3 px/ft = 300 px
-    const xs = signs.map((s) => s.x).sort((a, b) => b - a)
-    expect(xs[0]).toBeCloseTo(1000 - 300)
+    expect(ds.taperLength).toBeCloseTo(calcTaperLength(taper.speed, taper.laneWidth, taper.numLanes))
+    expect(ds.laneWidth).toBe(taper.laneWidth)
+    expect(ds.numLanes).toBe(taper.numLanes)
+    expect(ds.manualLength).toBe(false)
   })
 })

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -8,7 +8,7 @@ import type {
   MapCenter, PlanMeta, Point,
   GeocodeResult,
 } from './types';
-import { uid, geoRoadWidthPx, formatSearchPrimary, geocodeAddress, cloneObject } from './utils';
+import { uid, geoRoadWidthPx, formatSearchPrimary, geocodeAddress, cloneObject, autoChannelize } from './utils';
 import { savePlanToCloud, fetchRemoteUpdatedAt, loadPlanFromCloud } from './planStorage';
 import { buildGeoContext, worldToPlan } from './coordinate-bridge';
 import { detectSchemaVersion, v2ToWorldCoords } from './planMigration';
@@ -364,6 +364,13 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     else if (dir === "forward")  next.splice(idx + 1, 0, obj);
     else                         next.splice(idx - 1, 0, obj);
     pushHistory(next);
+  };
+
+  const handleAutoChannelize = (taperId: string, workZoneLengthFt: number) => {
+    const taper = objects.find((o) => o.id === taperId);
+    if (!taper || taper.type !== 'taper') return;
+    const newObjs = autoChannelize(taper, workZoneLengthFt);
+    pushHistory([...objects, ...newObjs]);
   };
 
   const clearAll = () => {
@@ -1335,7 +1342,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
               <button type="button" onClick={() => setRightPanel(false)} data-testid="close-right-panel" style={{ background: "none", border: "none", color: COLORS.textDim, cursor: "pointer", fontSize: 14, padding: "0 10px" }}>×</button>
             </div>
             {rightTab === "properties"
-              ? <PropertyPanel selected={selected} objects={objects} onUpdate={updateObject} onDelete={deleteObject} onReorder={reorderObject} planMeta={planMeta} onUpdateMeta={setPlanMeta} />
+              ? <PropertyPanel selected={selected} objects={objects} onUpdate={updateObject} onDelete={deleteObject} onReorder={reorderObject} planMeta={planMeta} onUpdateMeta={setPlanMeta} onAutoChannelize={handleAutoChannelize} />
               : rightTab === "manifest"
               ? <ManifestPanel objects={objects} />
               : <QCPanel issues={qcIssues} />

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -3,6 +3,7 @@ import type {
   SignObject, DeviceObject, ZoneObject, TextObject, TaperObject, TurnLaneObject,
   StraightRoadObject, PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject, ArrowObject, MeasureObject, LaneMaskObject, CrosswalkObject,
 } from './types'
+import { TAPER_SCALE, SIGN_LATERAL_CLEARANCE_PX } from './features/tcp/constants'
 
 // ─── CLONE / DUPLICATE ────────────────────────────────────────────────────────
 
@@ -76,9 +77,6 @@ export const uid = () => Math.random().toString(36).slice(2, 10)
 
 // ─── AUTO-CHANNELIZATION ──────────────────────────────────────────────────────
 
-/** Canvas pixels per foot (matches ObjectShapes.tsx TAPER_SCALE). */
-const TAPER_PX_PER_FT = 3
-
 /** MUTCD Table 6H-3: advance warning sign spacing by posted speed. */
 function mutcdSignSpacingFt(speedMph: number): number {
   if (speedMph <= 35) return 100
@@ -100,13 +98,13 @@ function mutcdSignSpacingFt(speedMph: number): number {
  * @returns New CanvasObject[] to push onto the canvas
  */
 export function autoChannelize(taper: TaperObject, workZoneLengthFt: number): CanvasObject[] {
-  const spacingPx = mutcdSignSpacingFt(taper.speed) * TAPER_PX_PER_FT
+  const spacingPx = mutcdSignSpacingFt(taper.speed) * TAPER_SCALE
   const rotRad = (taper.rotation * Math.PI) / 180
 
-  const totalWidthPx = taper.laneWidth * taper.numLanes * TAPER_PX_PER_FT
+  const totalWidthPx = taper.laneWidth * taper.numLanes * TAPER_SCALE
   const hw = totalWidthPx / 2
   // Place signs to the right of the road (driver's right when approaching taper)
-  const lateralOffsetPx = hw + 30
+  const lateralOffsetPx = hw + SIGN_LATERAL_CLEARANCE_PX
 
   /** Convert local taper-space (lx, ly) → world canvas coords. */
   function toWorld(lx: number, ly: number): { x: number; y: number } {
@@ -143,9 +141,9 @@ export function autoChannelize(taper: TaperObject, workZoneLengthFt: number): Ca
   // local space with rotation+180 so the wide end faces away from the work zone
   // and the narrow end abuts the work zone boundary.
   const dsTaperLengthFt = calcTaperLength(taper.speed, taper.laneWidth, taper.numLanes)
-  const dsTaperLengthPx = dsTaperLengthFt * TAPER_PX_PER_FT
-  const mergeTaperPx = taper.taperLength * TAPER_PX_PER_FT
-  const workZonePx = workZoneLengthFt * TAPER_PX_PER_FT
+  const dsTaperLengthPx = dsTaperLengthFt * TAPER_SCALE
+  const mergeTaperPx = taper.taperLength * TAPER_SCALE
+  const workZonePx = workZoneLengthFt * TAPER_SCALE
   const dsLocalX = mergeTaperPx + workZonePx + dsTaperLengthPx
   const dsPos = toWorld(dsLocalX, 0)
 

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -74,6 +74,97 @@ export function calcTaperLength(speed: number, laneWidth: number, numLanes: numb
 
 export const uid = () => Math.random().toString(36).slice(2, 10)
 
+// ─── AUTO-CHANNELIZATION ──────────────────────────────────────────────────────
+
+/** Canvas pixels per foot (matches ObjectShapes.tsx TAPER_SCALE). */
+const TAPER_PX_PER_FT = 3
+
+/** MUTCD Table 6H-3: advance warning sign spacing by posted speed. */
+function mutcdSignSpacingFt(speedMph: number): number {
+  if (speedMph <= 35) return 100
+  if (speedMph <= 45) return 200
+  if (speedMph <= 55) return 350
+  if (speedMph <= 65) return 500
+  return 600
+}
+
+/**
+ * Generate MUTCD-compliant work zone objects for a lane closure.
+ *
+ * Places 3 advance warning signs upstream of the taper at Table 6H-3 spacing,
+ * plus a downstream (termination) taper at the far end of the work zone.
+ * All returned objects are normal canvas objects the user can move/edit.
+ *
+ * @param taper           The merge taper already on canvas
+ * @param workZoneLengthFt Length of the work zone in feet (between tapers)
+ * @returns New CanvasObject[] to push onto the canvas
+ */
+export function autoChannelize(taper: TaperObject, workZoneLengthFt: number): CanvasObject[] {
+  const spacingPx = mutcdSignSpacingFt(taper.speed) * TAPER_PX_PER_FT
+  const rotRad = (taper.rotation * Math.PI) / 180
+
+  const totalWidthPx = taper.laneWidth * taper.numLanes * TAPER_PX_PER_FT
+  const hw = totalWidthPx / 2
+  // Place signs to the right of the road (driver's right when approaching taper)
+  const lateralOffsetPx = hw + 30
+
+  /** Convert local taper-space (lx, ly) → world canvas coords. */
+  function toWorld(lx: number, ly: number): { x: number; y: number } {
+    return {
+      x: taper.x + lx * Math.cos(rotRad) - ly * Math.sin(rotRad),
+      y: taper.y + lx * Math.sin(rotRad) + ly * Math.cos(rotRad),
+    }
+  }
+
+  // Advance warning signs — nearest to farthest from the taper
+  const advanceSigns = [
+    { id: 'onelane',   label: 'ONE LANE RD', shape: 'rect'   , color: '#f97316', textColor: '#111', mutcd: 'W20-4a' },
+    { id: 'roadwork',  label: 'ROAD WORK',   shape: 'diamond', color: '#f97316', textColor: '#111', mutcd: 'W20-1'  },
+    { id: 'workahead', label: 'WORK AHEAD',  shape: 'diamond', color: '#f97316', textColor: '#111', mutcd: 'W20-1'  },
+  ] as const
+
+  const result: CanvasObject[] = []
+
+  advanceSigns.forEach((signData, i) => {
+    const pos = toWorld(-(i + 1) * spacingPx, lateralOffsetPx)
+    result.push({
+      id: uid(),
+      type: 'sign',
+      x: pos.x,
+      y: pos.y,
+      rotation: taper.rotation,
+      scale: 1,
+      signData: { ...signData },
+    } as SignObject)
+  })
+
+  // Downstream (termination) taper at the far end of the work zone.
+  // We place its origin at (taperLengthPx + workZonePx + dsTaperLengthPx) in
+  // local space with rotation+180 so the wide end faces away from the work zone
+  // and the narrow end abuts the work zone boundary.
+  const dsTaperLengthFt = calcTaperLength(taper.speed, taper.laneWidth, taper.numLanes)
+  const dsTaperLengthPx = dsTaperLengthFt * TAPER_PX_PER_FT
+  const mergeTaperPx = taper.taperLength * TAPER_PX_PER_FT
+  const workZonePx = workZoneLengthFt * TAPER_PX_PER_FT
+  const dsLocalX = mergeTaperPx + workZonePx + dsTaperLengthPx
+  const dsPos = toWorld(dsLocalX, 0)
+
+  result.push({
+    id: uid(),
+    type: 'taper',
+    x: dsPos.x,
+    y: dsPos.y,
+    rotation: (taper.rotation + 180) % 360,
+    laneWidth: taper.laneWidth,
+    speed: taper.speed,
+    taperLength: dsTaperLengthFt,
+    manualLength: false,
+    numLanes: taper.numLanes,
+  } as TaperObject)
+
+  return result
+}
+
 export const dist = (x1: number, y1: number, x2: number, y2: number) =>
   Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 


### PR DESCRIPTION
## Summary
- Adds `autoChannelize(taper, workZoneLengthFt)` utility in `utils.ts` that generates MUTCD Table 6H-3 compliant advance warning signs (ONE LANE RD → ROAD WORK → WORK AHEAD at speed-appropriate spacing) plus a downstream termination taper
- Adds "Auto-Channelize" section to the taper Property Panel with a work zone length slider (100–5000 ft) and an "Auto-Channelize" button
- All placed objects are normal canvas objects the user can move/edit after placement

Closes #197

## Test plan
- [ ] Place a taper, select it, open Properties panel
- [ ] Verify "Auto-Channelize" section appears below Rotation with work zone length slider
- [ ] Click "Auto-Channelize" → 3 advance warning signs appear upstream and a downstream taper appears at the far end
- [ ] Verify spacing at 45 mph = 200 ft apart (600 px) between signs
- [ ] Verify all placed objects can be selected and moved individually
- [ ] `npm run test -- --run` passes (399/399)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add automatic MUTCD-compliant channelization for tapers, including advance warning signs and a downstream termination taper, and expose it via the taper property panel.

New Features:
- Introduce autoChannelize utility to generate MUTCD Table 6H-3–compliant advance warning signs and a downstream taper based on an existing taper and work zone length.
- Add an Auto-Channelize control to the taper property panel with a configurable work zone length slider and trigger button.

Tests:
- Add unit tests covering autoChannelize output types, object counts, spacing behavior at different speeds, and downstream taper placement and rotation.