### PR TITLE
feat(canvas): MUTCD spacing guide overlay for taper objects

### DIFF
--- a/my-app/src/components/tcp/canvas/SpacingOverlay.tsx
+++ b/my-app/src/components/tcp/canvas/SpacingOverlay.tsx
@@ -1,0 +1,111 @@
+import { Group, Line, Text, Circle } from 'react-konva';
+import type { TaperObject } from '../../../types';
+import { TAPER_SCALE, SIGN_LATERAL_CLEARANCE_PX } from '../../../features/tcp/constants';
+
+/** MUTCD Table 6H-3 advance warning sign spacing by speed. */
+function mutcdSpacingFt(speed: number): number {
+  if (speed <= 35) return 100;
+  if (speed <= 45) return 200;
+  if (speed <= 55) return 350;
+  if (speed <= 65) return 500;
+  return 600;
+}
+
+const SIGN_SEQUENCE = [
+  { label: 'ONE LANE RD', mutcd: 'W20-4a' },
+  { label: 'ROAD WORK',   mutcd: 'W20-1'  },
+  { label: 'WORK AHEAD',  mutcd: 'W20-1'  },
+] as const;
+
+const GUIDE_COLOR  = 'rgba(99,179,237,0.75)';
+const LABEL_COLOR  = 'rgba(99,179,237,0.95)';
+const SIGN_COLOR   = 'rgba(249,115,22,0.9)';
+
+interface SpacingOverlayProps {
+  taper: TaperObject;
+}
+
+export function SpacingOverlay({ taper }: SpacingOverlayProps) {
+  const spacingFt = mutcdSpacingFt(taper.speed);
+  const spacingPx = spacingFt * TAPER_SCALE;
+  const hw = (taper.laneWidth * taper.numLanes * TAPER_SCALE) / 2;
+  const lineHalfLen = hw + 90;
+  const signDotX = hw + SIGN_LATERAL_CLEARANCE_PX;
+
+  return (
+    <Group x={taper.x} y={taper.y} rotation={taper.rotation} listening={false}>
+      {/* Road-width indicator at taper origin */}
+      <Line
+        points={[0, -hw, 0, hw]}
+        stroke="rgba(249,115,22,0.45)"
+        strokeWidth={2}
+        dash={[4, 4]}
+        listening={false}
+      />
+
+      {SIGN_SEQUENCE.map(({ label, mutcd }, i) => {
+        const lx = -(i + 1) * spacingPx;
+        const distFt = (i + 1) * spacingFt;
+
+        return (
+          <Group key={i} x={lx} y={0} listening={false}>
+            {/* Dashed guide line perpendicular to road */}
+            <Line
+              points={[0, -lineHalfLen, 0, lineHalfLen]}
+              stroke={GUIDE_COLOR}
+              strokeWidth={1.5}
+              dash={[8, 5]}
+              listening={false}
+            />
+
+            {/* Distance label — top of line */}
+            <Text
+              x={5}
+              y={-lineHalfLen}
+              text={`${distFt} ft`}
+              fontSize={11}
+              fontStyle="bold"
+              fill={LABEL_COLOR}
+              listening={false}
+            />
+
+            {/* Sign name + MUTCD code — just below distance */}
+            <Text
+              x={5}
+              y={-lineHalfLen + 14}
+              text={`${label} (${mutcd})`}
+              fontSize={9}
+              fill={SIGN_COLOR}
+              listening={false}
+            />
+
+            {/* Dot at the expected sign position (right of road) */}
+            <Circle
+              x={signDotX}
+              y={0}
+              radius={5}
+              fill={GUIDE_COLOR}
+              stroke="rgba(255,255,255,0.5)"
+              strokeWidth={1}
+              listening={false}
+            />
+
+            {/* Tick at road edge */}
+            <Line
+              points={[0, -hw - 6, 0, -hw + 6]}
+              stroke={GUIDE_COLOR}
+              strokeWidth={2}
+              listening={false}
+            />
+            <Line
+              points={[0, hw - 6, 0, hw + 6]}
+              stroke={GUIDE_COLOR}
+              strokeWidth={2}
+              listening={false}
+            />
+          </Group>
+        );
+      })}
+    </Group>
+  );
+}

--- a/my-app/src/components/tcp/canvas/SpacingOverlay.tsx
+++ b/my-app/src/components/tcp/canvas/SpacingOverlay.tsx
@@ -41,7 +41,7 @@ export function SpacingOverlay({ taper }: SpacingOverlayProps) {
         const distFt = (i + 1) * spacingFt;
 
         return (
-          <Group key={i} x={lx} y={0} listening={false}>
+          <Group key={mutcd + label} x={lx} y={0} listening={false}>
             {/* Dashed guide line perpendicular to road */}
             <Line
               points={[0, -lineHalfLen, 0, lineHalfLen]}

--- a/my-app/src/components/tcp/canvas/SpacingOverlay.tsx
+++ b/my-app/src/components/tcp/canvas/SpacingOverlay.tsx
@@ -1,15 +1,7 @@
 import { Group, Line, Text, Circle } from 'react-konva';
 import type { TaperObject } from '../../../types';
 import { TAPER_SCALE, SIGN_LATERAL_CLEARANCE_PX } from '../../../features/tcp/constants';
-
-/** MUTCD Table 6H-3 advance warning sign spacing by speed. */
-function mutcdSpacingFt(speed: number): number {
-  if (speed <= 35) return 100;
-  if (speed <= 45) return 200;
-  if (speed <= 55) return 350;
-  if (speed <= 65) return 500;
-  return 600;
-}
+import { mutcdSignSpacingFt } from '../../../utils';
 
 const SIGN_SEQUENCE = [
   { label: 'ONE LANE RD', mutcd: 'W20-4a' },
@@ -17,20 +9,21 @@ const SIGN_SEQUENCE = [
   { label: 'WORK AHEAD',  mutcd: 'W20-1'  },
 ] as const;
 
-const GUIDE_COLOR  = 'rgba(99,179,237,0.75)';
-const LABEL_COLOR  = 'rgba(99,179,237,0.95)';
-const SIGN_COLOR   = 'rgba(249,115,22,0.9)';
+const GUIDE_COLOR = 'rgba(99,179,237,0.75)';
+const LABEL_COLOR = 'rgba(99,179,237,0.95)';
+const SIGN_COLOR  = 'rgba(249,115,22,0.9)';
 
 interface SpacingOverlayProps {
   taper: TaperObject;
 }
 
 export function SpacingOverlay({ taper }: SpacingOverlayProps) {
-  const spacingFt = mutcdSpacingFt(taper.speed);
+  const spacingFt = mutcdSignSpacingFt(taper.speed);
   const spacingPx = spacingFt * TAPER_SCALE;
   const hw = (taper.laneWidth * taper.numLanes * TAPER_SCALE) / 2;
   const lineHalfLen = hw + 90;
-  const signDotX = hw + SIGN_LATERAL_CLEARANCE_PX;
+  // Lateral (y-axis in taper-local space) offset to the expected sign position
+  const signDotY = hw + SIGN_LATERAL_CLEARANCE_PX;
 
   return (
     <Group x={taper.x} y={taper.y} rotation={taper.rotation} listening={false}>
@@ -79,10 +72,10 @@ export function SpacingOverlay({ taper }: SpacingOverlayProps) {
               listening={false}
             />
 
-            {/* Dot at the expected sign position (right of road) */}
+            {/* Dot at the expected sign position — lateral offset (y) in taper-local space */}
             <Circle
-              x={signDotX}
-              y={0}
+              x={0}
+              y={signDotY}
               radius={5}
               fill={GUIDE_COLOR}
               stroke="rgba(255,255,255,0.5)"
@@ -90,7 +83,7 @@ export function SpacingOverlay({ taper }: SpacingOverlayProps) {
               listening={false}
             />
 
-            {/* Tick at road edge */}
+            {/* Tick marks at road edges */}
             <Line
               points={[0, -hw - 6, 0, -hw + 6]}
               stroke={GUIDE_COLOR}

--- a/my-app/src/components/tcp/panels/PropertyPanel.tsx
+++ b/my-app/src/components/tcp/panels/PropertyPanel.tsx
@@ -15,9 +15,11 @@ interface PropertyPanelProps {
   planMeta: PlanMeta;
   onUpdateMeta: (meta: PlanMeta) => void;
   onAutoChannelize: (taperId: string, workZoneLengthFt: number) => void;
+  showSpacingGuide: boolean;
+  onToggleSpacingGuide: () => void;
 }
 
-export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder, planMeta, onUpdateMeta, onAutoChannelize }: PropertyPanelProps) {
+export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder, planMeta, onUpdateMeta, onAutoChannelize, showSpacingGuide, onToggleSpacingGuide }: PropertyPanelProps) {
   const [workZoneLength, setWorkZoneLength] = useState(500);
   if (!selected) {
     return (
@@ -128,6 +130,17 @@ export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder
                 style={{ width: "100%", accentColor: COLORS.accent }}
                 onChange={(e) => onUpdate(t.id, { rotation: +e.target.value })} />
             </label>
+            <div style={{ borderTop: `1px solid ${COLORS.panelBorder}`, paddingTop: 8, marginTop: 4 }}>
+              {sectionTitle("Spacing Guide")}
+              <div style={{ fontSize: 10, color: COLORS.textDim, marginBottom: 6 }}>
+                Show MUTCD Table 6H-3 advance warning sign distances on canvas
+              </div>
+              <button type="button"
+                style={{ ...panelBtnStyle, background: showSpacingGuide ? COLORS.info : undefined, color: showSpacingGuide ? '#fff' : undefined, width: '100%', marginBottom: 8 }}
+                onClick={onToggleSpacingGuide}>
+                {showSpacingGuide ? 'Hide Spacing Guide' : 'Show Spacing Guide'}
+              </button>
+            </div>
             <div style={{ borderTop: `1px solid ${COLORS.panelBorder}`, paddingTop: 8, marginTop: 4 }}>
               {sectionTitle("Auto-Channelize")}
               <label style={{ fontSize: 11, color: COLORS.textMuted }}>

--- a/my-app/src/components/tcp/panels/PropertyPanel.tsx
+++ b/my-app/src/components/tcp/panels/PropertyPanel.tsx
@@ -136,6 +136,7 @@ export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder
                 Show MUTCD Table 6H-3 advance warning sign distances on canvas
               </div>
               <button type="button"
+                aria-pressed={showSpacingGuide}
                 style={{ ...panelBtnStyle, background: showSpacingGuide ? COLORS.info : undefined, color: showSpacingGuide ? '#fff' : undefined, width: '100%', marginBottom: 8 }}
                 onClick={onToggleSpacingGuide}>
                 {showSpacingGuide ? 'Hide Spacing Guide' : 'Show Spacing Guide'}

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -3,7 +3,7 @@ import { Stage, Layer, Rect, Image as KonvaImage } from "react-konva";
 import type Konva from 'konva';
 import type React from 'react';
 import type {
-  CanvasObject, PolylineRoadObject,
+  CanvasObject, PolylineRoadObject, TaperObject,
   SignData, DeviceData, RoadType, DrawStart, PanStart,
   MapCenter, PlanMeta, Point,
   GeocodeResult,
@@ -20,6 +20,7 @@ import { track } from './analytics';
 import { DEVICES, ROAD_TYPES, SIGN_CATEGORIES, TOOLS, TOOLS_REQUIRING_MAP } from './features/tcp/tcpCatalog';
 import { GridLines, ObjectShape } from './components/tcp/canvas/ObjectShapes';
 import { DrawingOverlays } from './components/tcp/canvas/DrawingOverlays';
+import { SpacingOverlay } from './components/tcp/canvas/SpacingOverlay';
 import { ToolButton } from './components/tcp/ui/ToolButton';
 import { SignEditorPanel } from './components/tcp/panels/SignEditorPanel';
 import { COLORS, MIN_ZOOM, MAX_ZOOM } from './features/tcp/constants';
@@ -93,6 +94,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   const manifestTabRef = useRef<HTMLButtonElement | null>(null);
   const qcTabRef = useRef<HTMLButtonElement | null>(null);
   const [showGrid, setShowGrid] = useState(true);
+  const [showSpacingGuide, setShowSpacingGuide] = useState(false);
   const [showNorthArrow, setShowNorthArrow] = useState(true);
   const [showLegend, setShowLegend] = useState(true);
   const [snapEnabled, setSnapEnabled] = useState(true);
@@ -1187,6 +1189,10 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
                 curvePoints={curvePoints}
                 cubicPoints={cubicPoints}
               />
+              {showSpacingGuide && (() => {
+                const taper = objects.find((o) => o.id === selected && o.type === 'taper');
+                return taper ? <SpacingOverlay taper={taper as TaperObject} /> : null;
+              })()}
             </Layer>
           </Stage>
 
@@ -1342,7 +1348,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
               <button type="button" onClick={() => setRightPanel(false)} data-testid="close-right-panel" style={{ background: "none", border: "none", color: COLORS.textDim, cursor: "pointer", fontSize: 14, padding: "0 10px" }}>×</button>
             </div>
             {rightTab === "properties"
-              ? <PropertyPanel selected={selected} objects={objects} onUpdate={updateObject} onDelete={deleteObject} onReorder={reorderObject} planMeta={planMeta} onUpdateMeta={setPlanMeta} onAutoChannelize={handleAutoChannelize} />
+              ? <PropertyPanel selected={selected} objects={objects} onUpdate={updateObject} onDelete={deleteObject} onReorder={reorderObject} planMeta={planMeta} onUpdateMeta={setPlanMeta} onAutoChannelize={handleAutoChannelize} showSpacingGuide={showSpacingGuide} onToggleSpacingGuide={() => setShowSpacingGuide((v) => !v)} />
               : rightTab === "manifest"
               ? <ManifestPanel objects={objects} />
               : <QCPanel issues={qcIssues} />

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -731,6 +731,10 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     return [...builtIn, ...custom]
   })()
 
+  const selectedTaper = showSpacingGuide
+    ? objects.find((o): o is TaperObject => o.id === selected && o.type === 'taper') ?? null
+    : null;
+
   return (
     <div style={{ width: "100%", height: "100vh", display: "flex", flexDirection: "column", background: COLORS.bg, color: COLORS.text, fontFamily: "'JetBrains Mono', 'SF Mono', 'Fira Code', monospace", overflow: "hidden", userSelect: "none" }}>
       <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
@@ -1189,10 +1193,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
                 curvePoints={curvePoints}
                 cubicPoints={cubicPoints}
               />
-              {showSpacingGuide && (() => {
-                const taper = objects.find((o) => o.id === selected && o.type === 'taper');
-                return taper ? <SpacingOverlay taper={taper as TaperObject} /> : null;
-              })()}
+              {selectedTaper && <SpacingOverlay taper={selectedTaper} />}
             </Layer>
           </Stage>
 

--- a/my-app/src/utils.ts
+++ b/my-app/src/utils.ts
@@ -78,7 +78,7 @@ export const uid = () => Math.random().toString(36).slice(2, 10)
 // ─── AUTO-CHANNELIZATION ──────────────────────────────────────────────────────
 
 /** MUTCD Table 6H-3: advance warning sign spacing by posted speed. */
-function mutcdSignSpacingFt(speedMph: number): number {
+export function mutcdSignSpacingFt(speedMph: number): number {
   if (speedMph <= 35) return 100
   if (speedMph <= 45) return 200
   if (speedMph <= 55) return 350


### PR DESCRIPTION
## Summary
- New `SpacingOverlay.tsx` Konva component renders MUTCD Table 6H-3 advance warning sign spacing guides on the canvas when a taper is selected
- Dashed lines perpendicular to the taper at 1×/2×/3× spacing with distance labels, sign names (ONE LANE RD / ROAD WORK / WORK AHEAD), MUTCD codes, dot markers at expected sign positions, and road-edge tick marks
- "Show/Hide Spacing Guide" toggle button in the taper Property Panel
- Overlay is ephemeral — not saved to the plan, resets on page reload
- Scales correctly with any zoom level (Konva world coordinates)
- Handles arbitrary taper rotation via `Group rotation` prop

Closes #198

## Test plan
- [ ] Place a taper, select it, open Properties panel
- [ ] Verify "Spacing Guide" section appears above Auto-Channelize
- [ ] Click "Show Spacing Guide" → 3 dashed blue guide lines appear on canvas at correct spacing for the taper's speed
- [ ] Verify button turns blue and reads "Hide Spacing Guide"
- [ ] Change taper speed — guide lines update to new MUTCD spacing
- [ ] Rotate taper — guide lines rotate with it
- [ ] Zoom in/out — guide lines scale correctly
- [ ] Deselect taper — guide lines disappear
- [ ] Click "Hide Spacing Guide" or deselect → overlay gone, plan data unchanged
- [ ] `npm run test -- --run` passes (409/409)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an optional MUTCD spacing guide overlay for selected taper objects and expose a toggle in the property panel to show or hide it.

New Features:
- Introduce a canvas spacing overlay that visualizes MUTCD Table 6H-3 advance warning sign distances for a selected taper.
- Add a "Spacing Guide" section with a toggle button in the taper property panel to control visibility of the overlay.

Enhancements:
- Wire planner state so spacing guides track taper selection and respect zoom and rotation while remaining ephemeral to the plan data.