### PR TITLE
feat(canvas): multi-select — shift-click, marquee, group move/delete/copy-paste

### DIFF
--- a/my-app/src/hooks/useCanvasEvents.test.ts
+++ b/my-app/src/hooks/useCanvasEvents.test.ts
@@ -332,6 +332,39 @@ describe('useCanvasEvents multi-select', () => {
     expect(mocks.setDrawStart).toHaveBeenCalledWith(null)
   })
 
+  it('clicking an already-selected object in a multi-selection sets up groupOrigPositionsById on drawStart', () => {
+    const sign1: CanvasObject = { id: 'sign-1', type: 'sign', x: 24, y: 36, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const sign2: CanvasObject = { id: 'sign-2', type: 'sign', x: 100, y: 100, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [sign1, sign2],
+      selectedIds: ['sign-1', 'sign-2'],
+      // pointer at sign-1's position
+      stageRef: makeRef({
+        getPointerPosition: () => ({ x: 24, y: 36 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseDown({ evt: { button: 0, shiftKey: false } } as KonvaEventObject<MouseEvent>)
+    })
+
+    // Should NOT replace selection
+    expect(mocks.setSelectedIds).not.toHaveBeenCalled()
+    // Should set drawStart with groupOrigPositionsById containing both objects
+    expect(mocks.setDrawStart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'sign-1',
+        groupOrigPositionsById: expect.objectContaining({
+          'sign-1': expect.objectContaining({ ox: 24, oy: 36 }),
+          'sign-2': expect.objectContaining({ ox: 100, oy: 100 }),
+        }),
+      })
+    )
+  })
+
   it('non-shift click on a new object replaces the selection', () => {
     const sign: CanvasObject = { id: 'new-sign', type: 'sign', x: 24, y: 36, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
     const { props, mocks } = makeProps({

--- a/my-app/src/hooks/useCanvasEvents.test.ts
+++ b/my-app/src/hooks/useCanvasEvents.test.ts
@@ -51,7 +51,8 @@ function makeRef<T>(value: T): React.RefObject<T> {
 
 function makeProps(overrides: Partial<CanvasEventsProps> = {}) {
   const setObjects = vi.fn()
-  const setSelected = vi.fn()
+  const setSelectedIds = vi.fn()
+  const setMarquee = vi.fn()
   const setZoom = vi.fn()
   const setOffset = vi.fn()
   const setMapCenter = vi.fn()
@@ -71,7 +72,7 @@ function makeProps(overrides: Partial<CanvasEventsProps> = {}) {
     intersectionType: '4way',
     snapEnabled: false,
     objects: [],
-    selected: null,
+    selectedIds: [],
     zoom: 1,
     offset: { x: 0, y: 0 },
     mapCenter: null,
@@ -90,7 +91,8 @@ function makeProps(overrides: Partial<CanvasEventsProps> = {}) {
     lastClickTimeRef: makeRef(0),
     lastClickPosRef: makeRef<Point | null>(null),
     setObjects: setObjects as unknown as React.Dispatch<React.SetStateAction<CanvasObject[]>>,
-    setSelected: setSelected as unknown as React.Dispatch<React.SetStateAction<string | null>>,
+    setSelectedIds: setSelectedIds as unknown as React.Dispatch<React.SetStateAction<string[]>>,
+    setMarquee: setMarquee as unknown as React.Dispatch<React.SetStateAction<{ x: number; y: number; w: number; h: number } | null>>,
     setZoom: setZoom as unknown as React.Dispatch<React.SetStateAction<number>>,
     setOffset: setOffset as unknown as React.Dispatch<React.SetStateAction<Point>>,
     setMapCenter: setMapCenter as unknown as React.Dispatch<React.SetStateAction<MapCenter | null>>,
@@ -110,7 +112,8 @@ function makeProps(overrides: Partial<CanvasEventsProps> = {}) {
     props,
     mocks: {
       setObjects,
-      setSelected,
+      setSelectedIds,
+      setMarquee,
       setDrawStart,
       setSnapIndicator,
       setCursorPos,
@@ -141,7 +144,7 @@ describe('useCanvasEvents null tool selections', () => {
     expect(mocks.setSnapIndicator).toHaveBeenCalledWith(null)
     expect(mocks.setObjects).not.toHaveBeenCalled()
     expect(mocks.pushHistory).not.toHaveBeenCalled()
-    expect(mocks.setSelected).not.toHaveBeenCalled()
+    expect(mocks.setSelectedIds).not.toHaveBeenCalled()
     expect(track).not.toHaveBeenCalled()
   })
 
@@ -162,7 +165,7 @@ describe('useCanvasEvents null tool selections', () => {
     expect(mocks.setSnapIndicator).toHaveBeenCalledWith(null)
     expect(mocks.setObjects).not.toHaveBeenCalled()
     expect(mocks.pushHistory).not.toHaveBeenCalled()
-    expect(mocks.setSelected).not.toHaveBeenCalled()
+    expect(mocks.setSelectedIds).not.toHaveBeenCalled()
     expect(track).not.toHaveBeenCalled()
   })
 
@@ -199,7 +202,7 @@ describe('useCanvasEvents null tool selections', () => {
     })
     expect(nextObjects[0].id).toEqual(expect.any(String))
     expect(mocks.setObjects).not.toHaveBeenCalled()
-    expect(mocks.setSelected).toHaveBeenCalledWith(nextObjects[0].id)
+    expect(mocks.setSelectedIds).toHaveBeenCalledWith([nextObjects[0].id])
     expect(mocks.setDrawStart).toHaveBeenCalledWith(null)
     expect(track).toHaveBeenCalledWith('road_drawn', {
       road_type: ROAD_TYPE.id,
@@ -226,8 +229,126 @@ describe('useCanvasEvents null tool selections', () => {
 
     expect(mocks.setObjects).not.toHaveBeenCalled()
     expect(mocks.pushHistory).not.toHaveBeenCalled()
-    expect(mocks.setSelected).not.toHaveBeenCalled()
+    expect(mocks.setSelectedIds).not.toHaveBeenCalled()
     expect(mocks.setDrawStart).toHaveBeenCalledWith(null)
     expect(track).not.toHaveBeenCalled()
+  })
+})
+
+describe('useCanvasEvents multi-select', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('clicking empty canvas clears selectedIds and starts a marquee drawStart', () => {
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [],
+      selectedIds: ['existing-id'],
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseDown({ evt: { button: 0, shiftKey: false } } as KonvaEventObject<MouseEvent>)
+    })
+
+    expect(mocks.setSelectedIds).toHaveBeenCalledWith([])
+    expect(mocks.setMarquee).toHaveBeenCalledWith(null)
+    expect(mocks.setDrawStart).toHaveBeenCalledWith(
+      expect.objectContaining({ isMarquee: true })
+    )
+  })
+
+  it('shift-click adds a hit object to the selection without clearing others', () => {
+    const sign: CanvasObject = { id: 'sign-1', type: 'sign', x: 24, y: 36, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [sign],
+      selectedIds: ['other-id'],
+      stageRef: makeRef({
+        getPointerPosition: () => ({ x: 24, y: 36 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseDown({ evt: { button: 0, shiftKey: true } } as KonvaEventObject<MouseEvent>)
+    })
+
+    // Should have called setSelectedIds with a function (updater) that adds sign-1
+    expect(mocks.setSelectedIds).toHaveBeenCalledTimes(1)
+    const updater = mocks.setSelectedIds.mock.calls[0][0]
+    const result2 = typeof updater === 'function' ? updater(['other-id']) : updater
+    expect(result2).toContain('sign-1')
+    expect(result2).toContain('other-id')
+  })
+
+  it('shift-click removes an already-selected object from the selection', () => {
+    const sign: CanvasObject = { id: 'sign-1', type: 'sign', x: 24, y: 36, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [sign],
+      selectedIds: ['sign-1', 'other-id'],
+      stageRef: makeRef({
+        getPointerPosition: () => ({ x: 24, y: 36 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseDown({ evt: { button: 0, shiftKey: true } } as KonvaEventObject<MouseEvent>)
+    })
+
+    const updater = mocks.setSelectedIds.mock.calls[0][0]
+    const result2 = typeof updater === 'function' ? updater(['sign-1', 'other-id']) : updater
+    expect(result2).not.toContain('sign-1')
+    expect(result2).toContain('other-id')
+  })
+
+  it('marquee mouseup selects objects whose center is inside the rect', () => {
+    const inSign: CanvasObject = { id: 'in-sign', type: 'sign', x: 50, y: 50, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const outSign: CanvasObject = { id: 'out-sign', type: 'sign', x: 200, y: 200, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [inSign, outSign],
+      drawStart: { x: 0, y: 0, isMarquee: true },
+      stageRef: makeRef({
+        // mouseup at world (100, 100) — marquee covers (0,0)→(100,100)
+        getPointerPosition: () => ({ x: 100, y: 100 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseUp({ evt: {} } as KonvaEventObject<MouseEvent>)
+    })
+
+    expect(mocks.setSelectedIds).toHaveBeenCalledWith(['in-sign'])
+    expect(mocks.setMarquee).toHaveBeenCalledWith(null)
+    expect(mocks.setDrawStart).toHaveBeenCalledWith(null)
+  })
+
+  it('non-shift click on a new object replaces the selection', () => {
+    const sign: CanvasObject = { id: 'new-sign', type: 'sign', x: 24, y: 36, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [sign],
+      selectedIds: ['old-id'],
+      stageRef: makeRef({
+        getPointerPosition: () => ({ x: 24, y: 36 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseDown({ evt: { button: 0, shiftKey: false } } as KonvaEventObject<MouseEvent>)
+    })
+
+    expect(mocks.setSelectedIds).toHaveBeenCalledWith(['new-sign'])
   })
 })

--- a/my-app/src/hooks/useCanvasEvents.test.ts
+++ b/my-app/src/hooks/useCanvasEvents.test.ts
@@ -351,4 +351,65 @@ describe('useCanvasEvents multi-select', () => {
 
     expect(mocks.setSelectedIds).toHaveBeenCalledWith(['new-sign'])
   })
+
+  it('group drag moves all selected objects together', () => {
+    const sign1: CanvasObject = { id: 'sign-1', type: 'sign', x: 10, y: 20, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const sign2: CanvasObject = { id: 'sign-2', type: 'sign', x: 50, y: 60, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    // drawStart is at pointer (24,36) with groupOrigPositionsById for both signs
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [sign1, sign2],
+      selectedIds: ['sign-1', 'sign-2'],
+      drawStart: {
+        x: 0, y: 0, id: 'sign-1',
+        groupOrigPositionsById: {
+          'sign-1': { id: 'sign-1', ox: 10, oy: 20 },
+          'sign-2': { id: 'sign-2', ox: 50, oy: 60 },
+        },
+      },
+      // mousemove pointer is at canvas (24, 36) → world (24, 36) → dx=24, dy=36
+      stageRef: makeRef({
+        getPointerPosition: () => ({ x: 24, y: 36 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseMove({ evt: {} } as KonvaEventObject<MouseEvent>)
+    })
+
+    expect(mocks.setObjects).toHaveBeenCalledTimes(1)
+    const updater = mocks.setObjects.mock.calls[0][0]
+    const updated = updater([sign1, sign2]) as CanvasObject[]
+    const s1 = updated.find((o) => o.id === 'sign-1') as typeof sign1
+    const s2 = updated.find((o) => o.id === 'sign-2') as typeof sign2
+    // Both signs should have moved by dx=24, dy=36
+    expect(s1.x).toBe(10 + 24)
+    expect(s1.y).toBe(20 + 36)
+    expect(s2.x).toBe(50 + 24)
+    expect(s2.y).toBe(60 + 36)
+  })
+
+  it('click without move does not push history', () => {
+    const sign: CanvasObject = { id: 'sign-1', type: 'sign', x: 24, y: 36, rotation: 0, scale: 1, signData: { id: 'r1-1', label: 'STOP', shape: 'octagon', color: '#f00', textColor: '#fff' } }
+    const { props, mocks } = makeProps({
+      tool: 'select',
+      objects: [sign],
+      drawStart: { x: 24, y: 36, id: 'sign-1', ox: 24, oy: 36 },
+      // mouseup pointer at same position — no movement
+      stageRef: makeRef({
+        getPointerPosition: () => ({ x: 24, y: 36 }),
+      } as unknown as Konva.Stage | null),
+    })
+
+    const { result } = renderHook(() => useCanvasEvents(props))
+
+    act(() => {
+      result.current.handleMouseUp({ evt: {} } as KonvaEventObject<MouseEvent>)
+    })
+
+    expect(mocks.pushHistory).not.toHaveBeenCalled()
+    expect(mocks.setDrawStart).toHaveBeenCalledWith(null)
+  })
 })

--- a/my-app/src/hooks/useCanvasEvents.ts
+++ b/my-app/src/hooks/useCanvasEvents.ts
@@ -180,10 +180,12 @@ export function useCanvasEvents({
       if (hit) {
         if (selectedIds.includes(hit.id) && selectedIds.length > 1) {
           // Clicking an already-selected object in a multi-selection → start group drag
-          const groupOrigPositions: GroupOrig[] = selectedIds.map((id) => {
+          // Use a Record for O(1) lookup per object during mousemove
+          const groupOrigPositionsById: Record<string, GroupOrig> = {};
+          for (const id of selectedIds) {
             const o = objects.find((obj) => obj.id === id);
-            if (!o) return { id };
-            return {
+            if (!o) { groupOrigPositionsById[id] = { id }; continue; }
+            groupOrigPositionsById[id] = {
               id,
               ox: isPointObject(o) ? o.x : isLineObject(o) ? o.x1 : undefined,
               oy: isPointObject(o) ? o.y : isLineObject(o) ? o.y1 : undefined,
@@ -191,8 +193,8 @@ export function useCanvasEvents({
               oy2: isLineObject(o) ? o.y2 : undefined,
               origPoints: isMultiPointRoad(o) ? o.points.map((p) => ({ ...p })) : null,
             };
-          });
-          setDrawStart({ x: raw.x, y: raw.y, id: hit.id, groupOrigPositions });
+          }
+          setDrawStart({ x: raw.x, y: raw.y, id: hit.id, groupOrigPositionsById });
         } else {
           // Select only this object and prepare single drag
           setSelectedIds([hit.id]);
@@ -372,10 +374,10 @@ export function useCanvasEvents({
       if (drawStart.id) {
         const dx = raw.x - drawStart.x, dy = raw.y - drawStart.y;
 
-        if (drawStart.groupOrigPositions?.length) {
-          // Group drag: move all selected objects using their stored originals
+        if (drawStart.groupOrigPositionsById) {
+          // Group drag: O(1) lookup per object using pre-built map
           setObjects((prev) => prev.map((o) => {
-            const orig = drawStart.groupOrigPositions!.find((g) => g.id === o.id);
+            const orig = drawStart.groupOrigPositionsById![o.id];
             if (!orig) return o;
             if (orig.origPoints) {
               return { ...o, points: orig.origPoints.map((p) => ({ x: p.x + dx, y: p.y + dy })) } as CanvasObject;
@@ -448,7 +450,12 @@ export function useCanvasEvents({
         return;
       }
       if (drawStart.id) {
-        pushHistory(objects); setDrawStart(null); return;
+        // Only snapshot history when the object actually moved
+        const raw = toWorld();
+        const dx = raw.x - drawStart.x, dy = raw.y - drawStart.y;
+        if (Math.abs(dx) > 1 || Math.abs(dy) > 1) pushHistory(objects);
+        setDrawStart(null);
+        return;
       }
       setDrawStart(null);
       return;

--- a/my-app/src/hooks/useCanvasEvents.ts
+++ b/my-app/src/hooks/useCanvasEvents.ts
@@ -5,7 +5,7 @@ import type React from 'react';
 import type {
   CanvasObject, StraightRoadObject, PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject,
   SignObject, DeviceObject, TaperObject, TurnLaneObject,
-  SignData, DeviceData, RoadType, DrawStart, PanStart, MapCenter, Point, SnapResult,
+  SignData, DeviceData, RoadType, DrawStart, GroupOrig, PanStart, MapCenter, Point, SnapResult,
 } from '../types';
 import {
   uid, dist, geoRoadWidthPx, snapToEndpoint, sampleBezier, sampleCubicBezier,
@@ -24,7 +24,7 @@ interface CanvasEventsProps {
   snapEnabled: boolean;
   // World state
   objects: CanvasObject[];
-  selected: string | null;
+  selectedIds: string[];
   zoom: number;
   offset: Point;
   mapCenter: MapCenter | null;
@@ -45,7 +45,8 @@ interface CanvasEventsProps {
   lastClickPosRef: React.RefObject<Point | null>;
   // Setters
   setObjects: React.Dispatch<React.SetStateAction<CanvasObject[]>>;
-  setSelected: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedIds: React.Dispatch<React.SetStateAction<string[]>>;
+  setMarquee: React.Dispatch<React.SetStateAction<{ x: number; y: number; w: number; h: number } | null>>;
   setZoom: React.Dispatch<React.SetStateAction<number>>;
   setOffset: React.Dispatch<React.SetStateAction<Point>>;
   setMapCenter: React.Dispatch<React.SetStateAction<MapCenter | null>>;
@@ -62,12 +63,12 @@ interface CanvasEventsProps {
 
 export function useCanvasEvents({
   tool, roadDrawMode, intersectionType, snapEnabled,
-  objects, selected, zoom, offset, mapCenter,
+  objects, selectedIds, zoom, offset, mapCenter,
   selectedSign, selectedDevice, selectedRoadType,
   polyPoints, curvePoints, cubicPoints,
   drawStart, isPanning, panStart,
   stageRef, lastClickTimeRef, lastClickPosRef,
-  setObjects, setSelected, setZoom, setOffset, setMapCenter,
+  setObjects, setSelectedIds, setMarquee, setZoom, setOffset, setMapCenter,
   setIsPanning, setPanStart, setDrawStart,
   setPolyPoints, setCurvePoints, setCubicPoints,
   setSnapIndicator, setCursorPos,
@@ -149,8 +150,9 @@ export function useCanvasEvents({
     }
 
     if (tool === "select") {
-      if (selected) {
-        const selObj = objects.find((o) => o.id === selected);
+      // Cubic bezier handle drag (only when a single bezier is selected)
+      if (selectedIds.length === 1) {
+        const selObj = objects.find((o) => o.id === selectedIds[0]);
         if (selObj?.type === "cubic_bezier_road") {
           const handleRadius = Math.min(10 / zoom, 20);
           for (let i = 0; i < selObj.points.length; i++) {
@@ -162,16 +164,51 @@ export function useCanvasEvents({
           }
         }
       }
+
       const hit = hitTest(raw.x, raw.y);
-      setSelected(hit ? hit.id : null);
+
+      if (e.evt.shiftKey) {
+        // Shift-click: toggle object in/out of selection
+        if (hit) {
+          setSelectedIds((prev) =>
+            prev.includes(hit.id) ? prev.filter((id) => id !== hit.id) : [...prev, hit.id]
+          );
+        }
+        return;
+      }
+
       if (hit) {
-        setDrawStart({
-          x: raw.x, y: raw.y,
-          ox: isPointObject(hit) ? hit.x : isLineObject(hit) ? hit.x1 : 0,
-          oy: isPointObject(hit) ? hit.y : isLineObject(hit) ? hit.y1 : 0,
-          id: hit.id,
-          origPoints: isMultiPointRoad(hit) ? hit.points.map((p) => ({ ...p })) : null,
-        });
+        if (selectedIds.includes(hit.id) && selectedIds.length > 1) {
+          // Clicking an already-selected object in a multi-selection → start group drag
+          const groupOrigPositions: GroupOrig[] = selectedIds.map((id) => {
+            const o = objects.find((obj) => obj.id === id);
+            if (!o) return { id };
+            return {
+              id,
+              ox: isPointObject(o) ? o.x : isLineObject(o) ? o.x1 : undefined,
+              oy: isPointObject(o) ? o.y : isLineObject(o) ? o.y1 : undefined,
+              ox2: isLineObject(o) ? o.x2 : undefined,
+              oy2: isLineObject(o) ? o.y2 : undefined,
+              origPoints: isMultiPointRoad(o) ? o.points.map((p) => ({ ...p })) : null,
+            };
+          });
+          setDrawStart({ x: raw.x, y: raw.y, id: hit.id, groupOrigPositions });
+        } else {
+          // Select only this object and prepare single drag
+          setSelectedIds([hit.id]);
+          setDrawStart({
+            x: raw.x, y: raw.y,
+            ox: isPointObject(hit) ? hit.x : isLineObject(hit) ? hit.x1 : 0,
+            oy: isPointObject(hit) ? hit.y : isLineObject(hit) ? hit.y1 : 0,
+            id: hit.id,
+            origPoints: isMultiPointRoad(hit) ? hit.points.map((p) => ({ ...p })) : null,
+          });
+        }
+      } else {
+        // Empty canvas: clear selection and start marquee
+        setSelectedIds([]);
+        setMarquee(null);
+        setDrawStart({ x: raw.x, y: raw.y, isMarquee: true });
       }
       return;
     }
@@ -180,7 +217,7 @@ export function useCanvasEvents({
       const hit = hitTest(raw.x, raw.y);
       if (hit) {
         const newObjs = objects.filter((o) => o.id !== hit.id);
-        pushHistory(newObjs); setSelected(null);
+        pushHistory(newObjs); setSelectedIds([]);
       }
       return;
     }
@@ -189,7 +226,7 @@ export function useCanvasEvents({
       if (!selectedSign) return;
       const newSign: SignObject = { id: uid(), type: "sign", x: raw.x, y: raw.y, signData: selectedSign, rotation: 0, scale: 1 };
       const newObjs = [...objects, newSign];
-      pushHistory(newObjs); setSelected(newSign.id);
+      pushHistory(newObjs); setSelectedIds([newSign.id]);
       const isCustom = selectedSign.id.startsWith('custom_');
       track('sign_placed', { sign_id: selectedSign.id, sign_source: isCustom ? 'custom' : 'builtin', ...(isCustom ? {} : { sign_label: selectedSign.label }) });
       return;
@@ -199,7 +236,7 @@ export function useCanvasEvents({
       if (!selectedDevice) return;
       const newDev: DeviceObject = { id: uid(), type: "device", x: raw.x, y: raw.y, deviceData: selectedDevice, rotation: 0 };
       const newObjs = [...objects, newDev];
-      pushHistory(newObjs); setSelected(newDev.id);
+      pushHistory(newObjs); setSelectedIds([newDev.id]);
       return;
     }
 
@@ -207,14 +244,14 @@ export function useCanvasEvents({
       const speed = 45, laneWidth = 12;
       const newTaper: TaperObject = { id: uid(), type: "taper", x: raw.x, y: raw.y, rotation: 0, speed, laneWidth, taperLength: calcTaperLength(speed, laneWidth), manualLength: false, numLanes: 1 };
       const newObjs = [...objects, newTaper];
-      pushHistory(newObjs); setSelected(newTaper.id);
+      pushHistory(newObjs); setSelectedIds([newTaper.id]);
       return;
     }
 
     if (tool === "turn_lane") {
       const newTL: TurnLaneObject = { id: uid(), type: "turn_lane", x: raw.x, y: raw.y, rotation: 0, laneWidth: 20, taperLength: 80, runLength: 100, side: 'right', turnDir: 'right' };
       const newObjs = [...objects, newTL];
-      pushHistory(newObjs); setSelected(newTL.id);
+      pushHistory(newObjs); setSelectedIds([newTL.id]);
       return;
     }
 
@@ -223,7 +260,7 @@ export function useCanvasEvents({
       if (textVal) {
         const newText = { id: uid(), type: "text" as const, x: raw.x, y: raw.y, text: textVal, fontSize: 14, bold: false, color: "#ffffff" };
         const newObjs = [...objects, newText];
-        pushHistory(newObjs); setSelected(newText.id);
+        pushHistory(newObjs); setSelectedIds([newText.id]);
       }
       return;
     }
@@ -240,7 +277,7 @@ export function useCanvasEvents({
         if (isDouble && polyPoints.length >= 2) {
           const newRoad: PolylineRoadObject = { id: uid(), type: "polyline_road", points: [...polyPoints], width: selectedRoadType.width, realWidth: selectedRoadType.realWidth, lanes: selectedRoadType.lanes, roadType: selectedRoadType.id, smooth: roadDrawMode === "smooth" };
           const newObjs = [...objects, newRoad];
-          pushHistory(newObjs); setSelected(newRoad.id); setPolyPoints([]);
+          pushHistory(newObjs); setSelectedIds([newRoad.id]); setPolyPoints([]);
           track('road_drawn', { road_type: selectedRoadType.id, draw_mode: roadDrawMode, point_count: polyPoints.length });
         } else {
           setPolyPoints((prev) => [...prev, { x, y }]);
@@ -253,7 +290,7 @@ export function useCanvasEvents({
         if (newCurvePts.length === 3) {
           const newRoad: CurveRoadObject = { id: uid(), type: "curve_road", points: newCurvePts as [Point, Point, Point], width: selectedRoadType.width, realWidth: selectedRoadType.realWidth, lanes: selectedRoadType.lanes, roadType: selectedRoadType.id };
           const newObjs = [...objects, newRoad];
-          pushHistory(newObjs); setSelected(newRoad.id); setCurvePoints([]);
+          pushHistory(newObjs); setSelectedIds([newRoad.id]); setCurvePoints([]);
           track('road_drawn', { road_type: selectedRoadType.id, draw_mode: 'curve', point_count: 3 });
         } else { setCurvePoints(newCurvePts); }
         return;
@@ -264,7 +301,7 @@ export function useCanvasEvents({
         if (newCubicPts.length === 4) {
           const newRoad: CubicBezierRoadObject = { id: uid(), type: "cubic_bezier_road", points: newCubicPts as [Point, Point, Point, Point], width: selectedRoadType.width, realWidth: selectedRoadType.realWidth, lanes: selectedRoadType.lanes, roadType: selectedRoadType.id };
           const newObjs = [...objects, newRoad];
-          pushHistory(newObjs); setSelected(newRoad.id); setCubicPoints([]);
+          pushHistory(newObjs); setSelectedIds([newRoad.id]); setCubicPoints([]);
           track('road_drawn', { road_type: selectedRoadType.id, draw_mode: 'cubic', point_count: 4 });
         } else { setCubicPoints(newCubicPts); }
         return;
@@ -274,7 +311,7 @@ export function useCanvasEvents({
     if (tool === "intersection") {
       const roads = createIntersectionRoads(x, y, intersectionType, selectedRoadType);
       const newObjs = [...objects, ...roads];
-      pushHistory(newObjs); setSelected(roads[roads.length - 1].id);
+      pushHistory(newObjs); setSelectedIds([roads[roads.length - 1].id]);
       track('road_drawn', { road_type: selectedRoadType.id, draw_mode: intersectionType === '4way' ? 'intersection_4way' : 'intersection_t' });
       return;
     }
@@ -284,12 +321,12 @@ export function useCanvasEvents({
     }
   }, [
     tool, roadDrawMode, intersectionType, snapEnabled,
-    objects, selected, zoom, offset, mapCenter,
+    objects, selectedIds, zoom, offset, mapCenter,
     selectedSign, selectedDevice, selectedRoadType,
     polyPoints, curvePoints, cubicPoints,
     stageRef, lastClickTimeRef, lastClickPosRef,
     toWorld, trySnap, hitTest,
-    setObjects, setSelected, setIsPanning, setPanStart, setDrawStart,
+    setObjects, setSelectedIds, setMarquee, setIsPanning, setPanStart, setDrawStart,
     setPolyPoints, setCurvePoints, setCubicPoints,
     setSnapIndicator, setCursorPos, pushHistory,
   ]);
@@ -321,39 +358,100 @@ export function useCanvasEvents({
       return;
     }
 
-    if (tool === "select" && drawStart && drawStart.id) {
-      const dx = raw.x - drawStart.x, dy = raw.y - drawStart.y;
-      setObjects((prev) => prev.map((o) => {
-        if (o.id !== drawStart.id) return o;
-        if (o.type === "cubic_bezier_road" && drawStart.origPoints) {
-          if (drawStart.handleIndex != null) {
-            const newPoints = drawStart.origPoints.map((p, i) =>
-              i === drawStart.handleIndex ? { x: p.x + dx, y: p.y + dy } : { ...p }
-            ) as [Point, Point, Point, Point];
-            return { ...o, points: newPoints };
-          }
-          return { ...o, points: drawStart.origPoints.map((p) => ({ x: p.x + dx, y: p.y + dy })) as [Point, Point, Point, Point] };
+    if (tool === "select" && drawStart) {
+      // Marquee update
+      if (drawStart.isMarquee) {
+        const mx = Math.min(drawStart.x, raw.x);
+        const my = Math.min(drawStart.y, raw.y);
+        const mw = Math.abs(raw.x - drawStart.x);
+        const mh = Math.abs(raw.y - drawStart.y);
+        setMarquee({ x: mx, y: my, w: mw, h: mh });
+        return;
+      }
+
+      if (drawStart.id) {
+        const dx = raw.x - drawStart.x, dy = raw.y - drawStart.y;
+
+        if (drawStart.groupOrigPositions?.length) {
+          // Group drag: move all selected objects using their stored originals
+          setObjects((prev) => prev.map((o) => {
+            const orig = drawStart.groupOrigPositions!.find((g) => g.id === o.id);
+            if (!orig) return o;
+            if (orig.origPoints) {
+              return { ...o, points: orig.origPoints.map((p) => ({ x: p.x + dx, y: p.y + dy })) } as CanvasObject;
+            }
+            if (isPointObject(o)) {
+              return { ...o, x: (orig.ox ?? 0) + dx, y: (orig.oy ?? 0) + dy } as CanvasObject;
+            }
+            if (isLineObject(o)) {
+              return { ...o, x1: (orig.ox ?? 0) + dx, y1: (orig.oy ?? 0) + dy, x2: (orig.ox2 ?? 0) + dx, y2: (orig.oy2 ?? 0) + dy } as CanvasObject;
+            }
+            return o;
+          }));
+        } else {
+          // Single object drag
+          setObjects((prev) => prev.map((o) => {
+            if (o.id !== drawStart.id) return o;
+            if (o.type === "cubic_bezier_road" && drawStart.origPoints) {
+              if (drawStart.handleIndex != null) {
+                const newPoints = drawStart.origPoints.map((p, i) =>
+                  i === drawStart.handleIndex ? { x: p.x + dx, y: p.y + dy } : { ...p }
+                ) as [Point, Point, Point, Point];
+                return { ...o, points: newPoints };
+              }
+              return { ...o, points: drawStart.origPoints.map((p) => ({ x: p.x + dx, y: p.y + dy })) as [Point, Point, Point, Point] };
+            }
+            if ((o.type === "polyline_road" || o.type === "curve_road") && drawStart.origPoints) {
+              return { ...o, points: drawStart.origPoints.map((p) => ({ x: p.x + dx, y: p.y + dy })) } as CanvasObject;
+            }
+            if (isPointObject(o)) {
+              return { ...o, x: (drawStart.ox ?? 0) + dx, y: (drawStart.oy ?? 0) + dy } as CanvasObject;
+            }
+            if (isLineObject(o)) {
+              const sdx = o.x2 - o.x1, sdy = o.y2 - o.y1;
+              return { ...o, x1: (drawStart.ox ?? 0) + dx, y1: (drawStart.oy ?? 0) + dy, x2: (drawStart.ox ?? 0) + dx + sdx, y2: (drawStart.oy ?? 0) + dy + sdy } as CanvasObject;
+            }
+            return o;
+          }));
         }
-        if ((o.type === "polyline_road" || o.type === "curve_road") && drawStart.origPoints) {
-          return { ...o, points: drawStart.origPoints.map((p) => ({ x: p.x + dx, y: p.y + dy })) } as CanvasObject;
-        }
-        if (isPointObject(o)) {
-          return { ...o, x: (drawStart.ox ?? 0) + dx, y: (drawStart.oy ?? 0) + dy } as CanvasObject;
-        }
-        if (isLineObject(o)) {
-          const sdx = o.x2 - o.x1, sdy = o.y2 - o.y1;
-          return { ...o, x1: (drawStart.ox ?? 0) + dx, y1: (drawStart.oy ?? 0) + dy, x2: (drawStart.ox ?? 0) + dx + sdx, y2: (drawStart.oy ?? 0) + dy + sdy } as CanvasObject;
-        }
-        return o;
-      }));
+      }
     }
-  }, [isPanning, panStart, toWorld, tool, drawStart, snapEnabled, objects, zoom, offset, mapCenter, setMapCenter, stageRef, setObjects, setOffset, setSnapIndicator, setCursorPos]);
+  }, [isPanning, panStart, toWorld, tool, drawStart, snapEnabled, objects, zoom, offset, mapCenter, setMapCenter, stageRef, setObjects, setOffset, setMarquee, setSnapIndicator, setCursorPos]);
 
   const handleMouseUp = useCallback((_e: KonvaEventObject<MouseEvent>) => {
     if (isPanning) { setIsPanning(false); setPanStart(null); return; }
 
-    if (tool === "select" && drawStart && drawStart.id) {
-      pushHistory(objects); setDrawStart(null); return;
+    if (tool === "select" && drawStart) {
+      if (drawStart.isMarquee) {
+        const raw = toWorld();
+        const mx1 = Math.min(drawStart.x, raw.x);
+        const my1 = Math.min(drawStart.y, raw.y);
+        const mx2 = Math.max(drawStart.x, raw.x);
+        const my2 = Math.max(drawStart.y, raw.y);
+        // Select all objects whose representative point falls inside the marquee
+        const inside = objects.filter((o) => {
+          if (isPointObject(o)) return o.x >= mx1 && o.x <= mx2 && o.y >= my1 && o.y <= my2;
+          if (isLineObject(o)) {
+            const cx = (o.x1 + o.x2) / 2, cy = (o.y1 + o.y2) / 2;
+            return cx >= mx1 && cx <= mx2 && cy >= my1 && cy <= my2;
+          }
+          if (isMultiPointRoad(o) && o.points.length > 0) {
+            const cx = o.points.reduce((s, p) => s + p.x, 0) / o.points.length;
+            const cy = o.points.reduce((s, p) => s + p.y, 0) / o.points.length;
+            return cx >= mx1 && cx <= mx2 && cy >= my1 && cy <= my2;
+          }
+          return false;
+        }).map((o) => o.id);
+        setSelectedIds(inside);
+        setMarquee(null);
+        setDrawStart(null);
+        return;
+      }
+      if (drawStart.id) {
+        pushHistory(objects); setDrawStart(null); return;
+      }
+      setDrawStart(null);
+      return;
     }
 
     if (drawStart && tool === "road" && roadDrawMode === "straight") {
@@ -363,7 +461,7 @@ export function useCanvasEvents({
       if (d < 5) { setDrawStart(null); return; }
       const newRoad: StraightRoadObject = { id: uid(), type: "road", x1: drawStart.x, y1: drawStart.y, x2: x, y2: y, width: selectedRoadType.width, realWidth: selectedRoadType.realWidth, lanes: selectedRoadType.lanes, roadType: selectedRoadType.id };
       const newObjs = [...objects, newRoad];
-      pushHistory(newObjs); setSelected(newRoad.id);
+      pushHistory(newObjs); setSelectedIds([newRoad.id]);
       track('road_drawn', { road_type: selectedRoadType.id, draw_mode: 'straight' });
       setDrawStart(null);
       return;
@@ -387,11 +485,11 @@ export function useCanvasEvents({
       }
       if (newObj) {
         const newObjs = [...objects, newObj];
-        pushHistory(newObjs); setSelected(newObj.id);
+        pushHistory(newObjs); setSelectedIds([newObj.id]);
       }
       setDrawStart(null);
     }
-  }, [isPanning, drawStart, tool, roadDrawMode, toWorld, trySnap, objects, selectedRoadType, pushHistory, setObjects, setSelected, setIsPanning, setPanStart, setDrawStart]);
+  }, [isPanning, drawStart, tool, roadDrawMode, toWorld, trySnap, objects, selectedRoadType, pushHistory, setObjects, setSelectedIds, setMarquee, setIsPanning, setPanStart, setDrawStart]);
 
   const handleWheel = useCallback((e: KonvaEventObject<WheelEvent>) => {
     const pos = stageRef.current?.getPointerPosition();

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -76,7 +76,9 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   // Core state
   const [tool, setTool] = useState("select");
   const { objects, setObjects, pushHistory, undo, redo, resetHistory } = useHistory(initialAutosave?.canvasState?.objects ?? []);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const selected = selectedIds[selectedIds.length - 1] ?? null;
+  const setSelected = (id: string | null) => setSelectedIds(id ? [id] : []);
   const [zoom, setZoom] = useState<number>(() => initialAutosave?.canvasZoom ?? 1);
   const [offset, setOffset] = useState<Point>(() => initialAutosave?.canvasOffset ?? { x: 0, y: 0 });
   const [canvasSize, setCanvasSize] = useState({ w: 800, h: 600 });
@@ -102,7 +104,8 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   const [planId, setPlanId] = useState<string>(() => initialAutosave?.id ?? uid());
   const [planCreatedAt, setPlanCreatedAt] = useState<string>(() => initialAutosave?.createdAt ?? new Date().toISOString());
   const [planMeta, setPlanMeta] = useState<PlanMeta>(() => initialAutosave?.metadata ?? { projectNumber: "", client: "", location: "", notes: "" });
-  const [clipboard, setClipboard] = useState<CanvasObject | null>(null);
+  const [clipboard, setClipboard] = useState<CanvasObject[] | null>(null);
+  const [marquee, setMarquee] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
   const [showDashboard, setShowDashboard] = useState(false);
   const [showTemplatePicker, setShowTemplatePicker] = useState(false);
   const [exportPreview, setExportPreview] = useState<Record<string, unknown> | null>(null);
@@ -263,36 +266,37 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
       const key = e.key.toUpperCase();
 
       if (e.metaKey || e.ctrlKey) {
-        if (key === "Z" && e.shiftKey) { e.preventDefault(); redo(); setSelected(null); return; }
-        if (key === "Z") { e.preventDefault(); undo(); setSelected(null); return; }
-        if (key === "Y") { e.preventDefault(); redo(); setSelected(null); return; }
-        if (key === "C" && selected) {
+        if (key === "Z" && e.shiftKey) { e.preventDefault(); redo(); setSelectedIds([]); return; }
+        if (key === "Z") { e.preventDefault(); undo(); setSelectedIds([]); return; }
+        if (key === "Y") { e.preventDefault(); redo(); setSelectedIds([]); return; }
+        if (key === "C" && selectedIds.length > 0) {
           e.preventDefault();
-          const obj = objects.find((o) => o.id === selected);
-          if (obj) setClipboard(obj);
+          const objs = objects.filter((o) => selectedIds.includes(o.id));
+          if (objs.length > 0) setClipboard(objs);
           return;
         }
         if (key === "V" && clipboard) {
           e.preventDefault();
-          const clone = cloneObject(clipboard);
-          const newObjs = [...objects, clone];
-          pushHistory(newObjs); setSelected(clone.id);
-          setClipboard(clone); // shift clipboard so repeated Ctrl+V continues to offset
+          const clones = clipboard.map((o) => cloneObject(o));
+          const newObjs = [...objects, ...clones];
+          pushHistory(newObjs); setSelectedIds(clones.map((c) => c.id));
+          setClipboard(clones); // shift clipboard so repeated Ctrl+V continues to offset
           return;
         }
-        if (key === "D" && selected) {
+        if (key === "D" && selectedIds.length > 0) {
           e.preventDefault();
-          const obj = objects.find((o) => o.id === selected);
-          if (obj) {
-            const clone = cloneObject(obj);
-            const newObjs = [...objects, clone];
-            pushHistory(newObjs); setSelected(clone.id);
+          const objs = objects.filter((o) => selectedIds.includes(o.id));
+          if (objs.length > 0) {
+            const clones = objs.map((o) => cloneObject(o));
+            pushHistory([...objects, ...clones]);
+            setSelectedIds(clones.map((c) => c.id));
           }
           return;
         }
       }
 
       if (key === "ESCAPE") {
+        setSelectedIds([]); setMarquee(null);
         setPolyPoints([]); setCurvePoints([]); setCubicPoints([]); setDrawStart(null); return;
       }
 
@@ -300,16 +304,16 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
         if (tool === "road" && (roadDrawMode === "poly" || roadDrawMode === "smooth") && polyPoints.length >= 2) {
           const newRoad: PolylineRoadObject = { id: uid(), type: "polyline_road", points: [...polyPoints], width: selectedRoadType.width, realWidth: selectedRoadType.realWidth, lanes: selectedRoadType.lanes, roadType: selectedRoadType.id, smooth: roadDrawMode === "smooth" };
           const newObjs = [...objects, newRoad];
-          pushHistory(newObjs); setSelected(newRoad.id); setPolyPoints([]);
+          pushHistory(newObjs); setSelectedIds([newRoad.id]); setPolyPoints([]);
           track('road_drawn', { road_type: selectedRoadType.id, draw_mode: roadDrawMode, point_count: polyPoints.length });
         }
         return;
       }
 
       if (key === "DELETE" || key === "BACKSPACE") {
-        if (selected) {
-          const newObjs = objects.filter((o) => o.id !== selected);
-          pushHistory(newObjs); setSelected(null);
+        if (selectedIds.length > 0) {
+          const newObjs = objects.filter((o) => !selectedIds.includes(o.id));
+          pushHistory(newObjs); setSelectedIds([]);
         }
         return;
       }
@@ -324,17 +328,17 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [selected, objects, clipboard, undo, redo, pushHistory, tool, roadDrawMode, polyPoints, selectedRoadType, requestTool]);
+  }, [selectedIds, objects, clipboard, undo, redo, pushHistory, tool, roadDrawMode, polyPoints, selectedRoadType, requestTool, setMarquee]);
 
   // Mouse handlers + toWorld/trySnap/hitTest — managed by useCanvasEvents hook
   const { handleMouseDown, handleMouseMove, handleMouseUp, handleWheel } = useCanvasEvents({
     tool, roadDrawMode, intersectionType, snapEnabled,
-    objects, selected, zoom, offset, mapCenter,
+    objects, selectedIds, zoom, offset, mapCenter,
     selectedSign, selectedDevice, selectedRoadType,
     polyPoints, curvePoints, cubicPoints,
     drawStart, isPanning, panStart,
     stageRef, lastClickTimeRef, lastClickPosRef,
-    setObjects, setSelected, setZoom, setOffset, setMapCenter,
+    setObjects, setSelectedIds, setMarquee, setZoom, setOffset, setMapCenter,
     setIsPanning, setPanStart, setDrawStart,
     setPolyPoints, setCurvePoints, setCubicPoints,
     setSnapIndicator, setCursorPos, pushHistory,
@@ -1173,7 +1177,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
             <Layer x={offset.x} y={offset.y} scaleX={zoom} scaleY={zoom}>
               {showGrid && <GridLines offset={offset} zoom={zoom} canvasSize={canvasSize} />}
               {objects.map((obj) => {
-                const isSel = obj.id === selected;
+                const isSel = selectedIds.includes(obj.id);
                 const robj = ('realWidth' in obj && (obj as { realWidth?: number }).realWidth && mapCenter)
                   ? { ...obj, width: geoRoadWidthPx(obj as { width: number; realWidth?: number }, mapCenter) }
                   : obj;
@@ -1194,6 +1198,17 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
                 cubicPoints={cubicPoints}
               />
               {selectedTaper && <SpacingOverlay taper={selectedTaper} />}
+              {marquee && (
+                <Rect
+                  x={marquee.x} y={marquee.y}
+                  width={marquee.w} height={marquee.h}
+                  fill="rgba(99,179,237,0.08)"
+                  stroke="rgba(99,179,237,0.7)"
+                  strokeWidth={1 / zoom}
+                  dash={[6 / zoom, 4 / zoom]}
+                  listening={false}
+                />
+              )}
             </Layer>
           </Stage>
 

--- a/my-app/src/types.ts
+++ b/my-app/src/types.ts
@@ -243,6 +243,15 @@ export interface MapCenter {
 
 // ─── INTERNAL UI TYPES ────────────────────────────────────────────────────────
 
+export interface GroupOrig {
+  id: string;
+  ox?: number;
+  oy?: number;
+  ox2?: number;
+  oy2?: number;
+  origPoints?: Point[] | null;
+}
+
 export interface DrawStart {
   x: number;
   y: number;
@@ -251,6 +260,8 @@ export interface DrawStart {
   id?: string;
   origPoints?: Point[] | null;
   handleIndex?: number | null; // index of the handle being dragged (cubic bezier only)
+  groupOrigPositions?: GroupOrig[];
+  isMarquee?: boolean;
 }
 
 export interface PanStart {

--- a/my-app/src/types.ts
+++ b/my-app/src/types.ts
@@ -260,7 +260,7 @@ export interface DrawStart {
   id?: string;
   origPoints?: Point[] | null;
   handleIndex?: number | null; // index of the handle being dragged (cubic bezier only)
-  groupOrigPositions?: GroupOrig[];
+  groupOrigPositionsById?: Record<string, GroupOrig>; // O(1) lookup for group drag
   isMarquee?: boolean;
 }
 


### PR DESCRIPTION
Closes #279

## Summary
- **Shift-click** toggles objects in/out of the selection set
- **Marquee select** — drag on empty canvas draws a dashed blue rect; on mouse-up all objects whose centroid falls inside are selected
- **Group move** — dragging any selected object in a multi-selection moves the entire group together
- **Delete / Backspace** removes all selected objects as a single undo step
- **Ctrl+C / Ctrl+V** copies and pastes the full group (with position offset; repeated Ctrl+V continues shifting)
- **Ctrl+D** duplicates the entire selection
- **Escape** clears selection and dismisses the marquee
- Click on empty canvas (no Shift) clears selection

## Implementation notes
- Replaces `selected: string | null` with `selectedIds: string[]` in `useCanvasEvents`; a derived `selected = selectedIds.at(-1) ?? null` keeps PropertyPanel and SpacingOverlay backward-compatible
- `DrawStart` extended with `groupOrigPositions` (snapshot of all selected objects' positions at drag-start) and `isMarquee` flag
- Clipboard promoted from `CanvasObject | null` to `CanvasObject[]` for group copy-paste
- Marquee rendered as a Konva `Rect` in the overlay layer (world-space coords, scaled with zoom)

## Test plan
- [x] 414 unit tests pass (5 new multi-select tests added)
- [ ] Shift-click adds/removes signs and roads from selection
- [ ] Drag on empty canvas shows marquee, selects contained objects on release
- [ ] Dragging a grouped selection moves all objects
- [ ] Delete removes all selected at once (single undo step)
- [ ] Ctrl+C → Ctrl+V pastes group; second Ctrl+V offsets again
- [ ] Escape clears selection and marquee

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add multi-object selection and group manipulation to the canvas, including marquee selection, group dragging, and multi-object keyboard operations.

New Features:
- Support selecting multiple canvas objects via shift-click toggling and marquee drag on empty canvas.
- Enable group drag, delete, copy-paste, and duplicate operations that act on all selected canvas objects.
- Display a marquee rectangle overlay while dragging to visually indicate the current selection area.

Enhancements:
- Refactor selection state from a single selected ID to an array of selected IDs while preserving backward compatibility for single-selection consumers.
- Extend canvas drag metadata to track original positions of multiple objects for coordinated group moves.
- Promote the clipboard from a single canvas object to an array of objects to support group copy-paste.

Tests:
- Add unit tests covering multi-select behaviors, including shift-click toggling, marquee selection, and selection replacement semantics.