### PR TITLE
Add Cognito post-confirmation signup notification Lambda

### DIFF
--- a/backend/cognito_post_confirmation.py
+++ b/backend/cognito_post_confirmation.py
@@ -58,9 +58,9 @@ def _send_signup_email(subject: str, body_text: str) -> None:
 
 
 def handler(event, context):
-    # Only notify on user-confirmation flows; return event unchanged for Cognito.
+    # Only notify on newly confirmed signups; return event unchanged for Cognito.
     trigger_source = event.get("triggerSource", "")
-    if trigger_source not in {"PostConfirmation_ConfirmSignUp", "PostConfirmation_ConfirmForgotPassword"}:
+    if trigger_source != "PostConfirmation_ConfirmSignUp":
         return event
 
     try:

--- a/backend/cognito_post_confirmation.py
+++ b/backend/cognito_post_confirmation.py
@@ -1,0 +1,72 @@
+import logging
+import os
+from datetime import datetime, timezone
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+
+def _build_signup_email(event: dict) -> tuple[str, str]:
+    attrs = event.get("request", {}).get("userAttributes", {}) or {}
+    username = event.get("userName", "")
+    trigger_source = event.get("triggerSource", "")
+
+    name = attrs.get("name") or "—"
+    email = attrs.get("email") or "—"
+    user_sub = attrs.get("sub") or "—"
+    confirmed_at = datetime.now(timezone.utc).isoformat()
+    app_env = os.getenv("APP_ENV", os.getenv("STAGE", "unknown"))
+
+    subject = f"New TCP Plan Pro signup: {email if email != '—' else username}"
+    body = "\n".join([
+        "A new user completed signup for TCP Plan Pro.",
+        "",
+        f"Name: {name}",
+        f"Email: {email}",
+        f"Username: {username or '—'}",
+        f"User Sub: {user_sub}",
+        f"Trigger Source: {trigger_source or '—'}",
+        f"Confirmed At: {confirmed_at}",
+        f"Environment: {app_env}",
+    ])
+    return subject, body
+
+
+def _send_signup_email(subject: str, body_text: str) -> None:
+    sender = os.getenv("SES_SENDER_EMAIL", "")
+    recipient = os.getenv("SIGNUP_NOTIFY_EMAIL", "")
+    if not sender or not recipient:
+        logger.warning("Signup email skipped — missing SES_SENDER_EMAIL or SIGNUP_NOTIFY_EMAIL")
+        return
+
+    ses_kwargs: dict = {}
+    ses_region = os.getenv("AWS_SES_REGION")
+    if ses_region:
+        ses_kwargs["region_name"] = ses_region
+    ses = boto3.client("ses", **ses_kwargs)
+    ses.send_email(
+        Source=sender,
+        Destination={"ToAddresses": [recipient]},
+        Message={
+            "Subject": {"Data": subject, "Charset": "UTF-8"},
+            "Body": {"Text": {"Data": body_text, "Charset": "UTF-8"}},
+        },
+        ReplyToAddresses=[sender],
+    )
+
+
+def handler(event, context):
+    # Only notify on user-confirmation flows; return event unchanged for Cognito.
+    trigger_source = event.get("triggerSource", "")
+    if trigger_source not in {"PostConfirmation_ConfirmSignUp", "PostConfirmation_ConfirmForgotPassword"}:
+        return event
+
+    try:
+        subject, body = _build_signup_email(event)
+        _send_signup_email(subject, body)
+    except (ClientError, BotoCoreError, Exception):
+        logger.exception("Failed to send signup notification email")
+
+    return event

--- a/backend/cognito_post_confirmation.py
+++ b/backend/cognito_post_confirmation.py
@@ -16,10 +16,10 @@ def _build_signup_email(event: dict) -> tuple[str, str]:
     name = attrs.get("name") or "—"
     email = attrs.get("email") or "—"
     user_sub = attrs.get("sub") or "—"
-    confirmed_at = datetime.now(timezone.utc).isoformat()
+    notification_sent_at = datetime.now(timezone.utc).isoformat()
     app_env = os.getenv("APP_ENV", os.getenv("STAGE", "unknown"))
 
-    subject = f"New TCP Plan Pro signup: {email if email != '—' else username}"
+    subject = f"New TCP Plan Pro signup: {email if email != '—' else (username or '—')}"
     body = "\n".join([
         "A new user completed signup for TCP Plan Pro.",
         "",
@@ -28,7 +28,7 @@ def _build_signup_email(event: dict) -> tuple[str, str]:
         f"Username: {username or '—'}",
         f"User Sub: {user_sub}",
         f"Trigger Source: {trigger_source or '—'}",
-        f"Confirmed At: {confirmed_at}",
+        f"Notification Sent At: {notification_sent_at}",
         f"Environment: {app_env}",
     ])
     return subject, body

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -20,6 +20,10 @@ Globals:
 Conditions:
   HasSesSenderEmail: !Not [!Equals [!Ref SesSenderEmail, ""]]
   HasSignupNotifyEmail: !Not [!Equals [!Ref SignupNotifyEmail, ""]]
+  # Both sender and notify email must be set before granting SES permissions to SignupNotifyFunction
+  HasSignupNotifyConfig: !And
+    - !Condition HasSesSenderEmail
+    - !Condition HasSignupNotifyEmail
 
 Parameters:
   Stage:
@@ -83,13 +87,13 @@ Resources:
     Properties:
       CodeUri: ./
       Handler: cognito_post_confirmation.handler
-      Description: Sends email notification for each confirmed Cognito signup
+      Description: Sends email notification when a new user completes Cognito signup (PostConfirmation_ConfirmSignUp only)
       Environment:
         Variables:
           SIGNUP_NOTIFY_EMAIL: !Ref SignupNotifyEmail
       Policies:
         - !If
-          - HasSesSenderEmail
+          - HasSignupNotifyConfig
           - Statement:
               - Effect: Allow
                 Action: ses:SendEmail

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -15,9 +15,11 @@ Globals:
         GITHUB_REPO: !Ref GitHubRepo
         ASSETS_BUCKET: !Ref TcpAssetsBucket
         SES_SENDER_EMAIL: !Ref SesSenderEmail
+        APP_ENV: !Ref Stage
 
 Conditions:
   HasSesSenderEmail: !Not [!Equals [!Ref SesSenderEmail, ""]]
+  HasSignupNotifyEmail: !Not [!Equals [!Ref SignupNotifyEmail, ""]]
 
 Parameters:
   Stage:
@@ -41,6 +43,10 @@ Parameters:
     Type: String
     Default: ""
     Description: "SES-verified From/To address for feedback notifications (e.g. jfisher@fisherconsulting.org)"
+  SignupNotifyEmail:
+    Type: String
+    Default: ""
+    Description: "Email address to notify for each confirmed Cognito signup"
 
 Resources:
 
@@ -64,6 +70,24 @@ Resources:
       Policies:
         - S3ReadPolicy:
             BucketName: !Ref TcpAssetsBucket
+        - !If
+          - HasSesSenderEmail
+          - Statement:
+              - Effect: Allow
+                Action: ses:SendEmail
+                Resource: !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${SesSenderEmail}"
+          - !Ref AWS::NoValue
+
+  SignupNotifyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./
+      Handler: cognito_post_confirmation.handler
+      Description: Sends email notification for each confirmed Cognito signup
+      Environment:
+        Variables:
+          SIGNUP_NOTIFY_EMAIL: !Ref SignupNotifyEmail
+      Policies:
         - !If
           - HasSesSenderEmail
           - Statement:
@@ -112,3 +136,6 @@ Outputs:
   FunctionArn:
     Description: "Lambda function ARN"
     Value: !GetAtt TcpApiFunction.Arn
+  SignupNotifyFunctionArn:
+    Description: "Lambda function ARN for Cognito post-confirmation notifications"
+    Value: !GetAtt SignupNotifyFunction.Arn

--- a/backend/tests/test_signup_notify.py
+++ b/backend/tests/test_signup_notify.py
@@ -1,0 +1,125 @@
+"""
+Tests for cognito_post_confirmation Lambda handler.
+
+All SES/boto3 calls are mocked — no real AWS credentials needed.
+"""
+import os
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+import cognito_post_confirmation as mod
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _event(trigger_source: str = "PostConfirmation_ConfirmSignUp", **attr_overrides) -> dict:
+    attrs = {
+        "sub": "abc-123",
+        "email": "user@example.com",
+        "name": "Alice",
+        **attr_overrides,
+    }
+    return {
+        "triggerSource": trigger_source,
+        "userName": "alice",
+        "request": {"userAttributes": attrs},
+        "version": "1",
+    }
+
+
+_SES_ENVS = {
+    "SES_SENDER_EMAIL": "sender@example.com",
+    "SIGNUP_NOTIFY_EMAIL": "admin@example.com",
+}
+
+
+# ── trigger filtering ─────────────────────────────────────────────────────────
+
+def test_forgot_password_trigger_skipped():
+    """ConfirmForgotPassword must be a no-op — no email sent."""
+    event = _event("PostConfirmation_ConfirmForgotPassword")
+    with patch("cognito_post_confirmation.boto3") as mock_boto3:
+        result = mod.handler(event, {})
+    mock_boto3.client.assert_not_called()
+    assert result is event
+
+
+def test_unknown_trigger_skipped():
+    event = _event("SomeOtherTrigger")
+    with patch("cognito_post_confirmation.boto3") as mock_boto3:
+        result = mod.handler(event, {})
+    mock_boto3.client.assert_not_called()
+    assert result is event
+
+
+def test_confirm_signup_trigger_sends_email():
+    """PostConfirmation_ConfirmSignUp must call SES when env vars are set."""
+    mock_ses = MagicMock()
+    with patch("cognito_post_confirmation.boto3.client", return_value=mock_ses), \
+         patch.dict(os.environ, _SES_ENVS):
+        result = mod.handler(_event(), {})
+    mock_ses.send_email.assert_called_once()
+    assert result["triggerSource"] == "PostConfirmation_ConfirmSignUp"
+
+
+# ── env-var guard ─────────────────────────────────────────────────────────────
+
+def test_missing_sender_email_skips_ses():
+    with patch("cognito_post_confirmation.boto3") as mock_boto3, \
+         patch.dict(os.environ, {"SIGNUP_NOTIFY_EMAIL": "admin@example.com"}, clear=True):
+        os.environ.pop("SES_SENDER_EMAIL", None)
+        mod.handler(_event(), {})
+    mock_boto3.client.assert_not_called()
+
+
+def test_missing_notify_email_skips_ses():
+    with patch("cognito_post_confirmation.boto3") as mock_boto3, \
+         patch.dict(os.environ, {"SES_SENDER_EMAIL": "sender@example.com"}, clear=True):
+        os.environ.pop("SIGNUP_NOTIFY_EMAIL", None)
+        mod.handler(_event(), {})
+    mock_boto3.client.assert_not_called()
+
+
+# ── SES error handling ────────────────────────────────────────────────────────
+
+def test_ses_client_error_swallowed():
+    """SES failure must not propagate — Cognito must still get the event back."""
+    from botocore.exceptions import ClientError
+    mock_ses = MagicMock()
+    mock_ses.send_email.side_effect = ClientError(
+        {"Error": {"Code": "MessageRejected", "Message": "Email address not verified"}},
+        "SendEmail",
+    )
+    with patch("cognito_post_confirmation.boto3.client", return_value=mock_ses), \
+         patch.dict(os.environ, _SES_ENVS):
+        result = mod.handler(_event(), {})
+    assert result["triggerSource"] == "PostConfirmation_ConfirmSignUp"
+
+
+# ── email content ─────────────────────────────────────────────────────────────
+
+def test_email_subject_uses_email_when_present():
+    subject, _ = mod._build_signup_email(_event())
+    assert "user@example.com" in subject
+
+
+def test_email_subject_falls_back_to_username():
+    event = _event(email=None)  # attrs.get("email") returns None → "—"
+    event["userName"] = "alice"
+    subject, _ = mod._build_signup_email(event)
+    assert "alice" in subject
+
+
+def test_email_subject_falls_back_to_dash_when_both_missing():
+    event = _event(email=None)
+    event["userName"] = ""
+    subject, _ = mod._build_signup_email(event)
+    assert subject.endswith("—")
+
+
+def test_email_body_contains_key_fields():
+    _, body = mod._build_signup_email(_event())
+    assert "user@example.com" in body
+    assert "Alice" in body
+    assert "abc-123" in body
+    assert "PostConfirmation_ConfirmSignUp" in body


### PR DESCRIPTION
## Summary
Adds a dedicated Lambda for Cognito post-confirmation signup notifications.

### Included
- `backend/cognito_post_confirmation.py`
  - Sends an SES email for each confirmed Cognito signup
  - Reuses the same SES approach already used by the backend feedback email flow
  - Returns the event unchanged for Cognito trigger compatibility
- `backend/template.yaml`
  - Adds `SignupNotifyFunction`
  - Adds `SignupNotifyEmail` parameter
  - Adds `APP_ENV` global env var
  - Adds `SignupNotifyFunctionArn` output

## Configuration
Required deploy parameters:
- `SesSenderEmail=<verified SES sender>`
- `SignupNotifyEmail=jfisher@fisherconsulting.org`

## Manual step after deploy
Because the Cognito user pool appears to be managed outside this SAM stack, attach the deployed Lambda as the **Post confirmation trigger** on the target Cognito user pool.

Trigger to set:
- Cognito User Pool -> Triggers -> Post confirmation -> `SignupNotifyFunction`

## Notes
- This PR prepares the Lambda and IAM permissions for SES sending.
- It does not attempt to mutate the external Cognito user pool from this stack.
- The handler currently notifies on:
  - `PostConfirmation_ConfirmSignUp`
  - `PostConfirmation_ConfirmForgotPassword`

If you only want true new-user signups, we should remove the forgot-password trigger path before merge.

## Summary by Sourcery

Add a new Lambda function and wiring to send SES-based notification emails on Cognito post-confirmation events.

New Features:
- Introduce a Cognito post-confirmation Lambda that sends signup notification emails via SES.
- Add a configurable signup notification recipient email and expose the Lambda ARN as a stack output.

Enhancements:
- Add a global APP_ENV environment variable for backend Lambdas to allow environment-aware behavior.