### PR TITLE
Enrich analytics events with auth and environment context

### DIFF
--- a/my-app/src/analytics.ts
+++ b/my-app/src/analytics.ts
@@ -5,6 +5,27 @@ function getKey(): string | undefined {
   return import.meta.env.VITE_POSTHOG_KEY as string | undefined
 }
 
+function getEnvironment(): string {
+  return (import.meta.env.MODE as string | undefined)
+    || (import.meta.env.VITE_APP_ENV as string | undefined)
+    || 'unknown'
+}
+
+type AnalyticsAuthState = 'identified' | 'anonymous'
+let authState: AnalyticsAuthState = 'anonymous'
+
+function getBaseProperties(): Record<string, unknown> {
+  return {
+    auth_state: authState,
+    environment: getEnvironment(),
+  }
+}
+
+function registerBaseProperties() {
+  if (!getKey()) return
+  posthog.register(getBaseProperties())
+}
+
 /** Call once at app startup. No-ops silently when the key is absent. */
 export function initAnalytics() {
   const key = getKey()
@@ -15,11 +36,14 @@ export function initAnalytics() {
     capture_pageview: true,
     autocapture: false,
   })
+  registerBaseProperties()
 }
 
 /** Tie all future events to the signed-in user. */
 export function identifyUser(userId: string, email: string | null) {
   if (!getKey()) return
+  authState = 'identified'
+  registerBaseProperties()
   posthog.identify(userId, { email: email ?? undefined })
 }
 
@@ -27,10 +51,15 @@ export function identifyUser(userId: string, email: string | null) {
 export function resetAnalytics() {
   if (!getKey()) return
   posthog.reset()
+  authState = 'anonymous'
+  registerBaseProperties()
 }
 
 /** Track a named event with optional properties. */
 export function track(event: string, properties?: Record<string, unknown>) {
   if (!getKey()) return
-  posthog.capture(event, properties)
+  posthog.capture(event, {
+    ...getBaseProperties(),
+    ...properties,
+  })
 }

--- a/my-app/src/analytics.ts
+++ b/my-app/src/analytics.ts
@@ -5,20 +5,16 @@ function getKey(): string | undefined {
   return import.meta.env.VITE_POSTHOG_KEY as string | undefined
 }
 
-function getEnvironment(): string {
-  return (import.meta.env.MODE as string | undefined)
-    || (import.meta.env.VITE_APP_ENV as string | undefined)
-    || 'unknown'
-}
+const environment: string =
+  (import.meta.env.MODE as string | undefined) ||
+  (import.meta.env.VITE_APP_ENV as string | undefined) ||
+  'unknown'
 
 type AnalyticsAuthState = 'identified' | 'anonymous'
 let authState: AnalyticsAuthState = 'anonymous'
 
 function getBaseProperties(): Record<string, unknown> {
-  return {
-    auth_state: authState,
-    environment: getEnvironment(),
-  }
+  return { auth_state: authState, environment }
 }
 
 function registerBaseProperties() {
@@ -58,8 +54,5 @@ export function resetAnalytics() {
 /** Track a named event with optional properties. */
 export function track(event: string, properties?: Record<string, unknown>) {
   if (!getKey()) return
-  posthog.capture(event, {
-    ...getBaseProperties(),
-    ...properties,
-  })
+  posthog.capture(event, properties)
 }

--- a/my-app/src/test/setup.ts
+++ b/my-app/src/test/setup.ts
@@ -102,6 +102,7 @@ vi.mock('posthog-js', () => ({
     identify: vi.fn(),
     reset: vi.fn(),
     capture: vi.fn(),
+    register: vi.fn(),
   },
 }))
 


### PR DESCRIPTION
## Summary
Adds baseline reporting context to all frontend PostHog events without changing the existing event names or planner flow.

### Changes
- `my-app/src/analytics.ts`
  - Adds automatic `auth_state` property to tracked events
  - Adds automatic `environment` property to tracked events
  - Registers these as PostHog super-properties at init/sign-in/sign-out time

## Why
This makes the existing event stream more useful for weekly access reporting immediately:
- filter main access KPIs to `auth_state = identified`
- separate anonymous usage from signed-in usage
- split dev/staging/prod activity cleanly

## Notes
This PR does **not** rename existing events or add new dashboard queries.
It enriches the current events already emitted by the planner, including:
- `app_session_started`
- `app_session_ended`
- `plan_saved_cloud`
- `plan_loaded_cloud`
- `plan_exported_png`

## Follow-up
A later small PR can add extra event properties such as:
- `plan_source`
- `cloud_saved` / `png_exported` flags on session end
- canonical `pdf_exported` reporting if needed

## Summary by Sourcery

Enrich frontend PostHog analytics events with consistent auth and environment context while preserving existing event names and flows.

New Features:
- Add automatic auth_state and environment properties to all tracked PostHog events.
- Register auth_state and environment as PostHog super-properties during analytics init, user identification, and reset.

Enhancements:
- Centralize computation of shared analytics base properties to ensure consistent event enrichment.