### PR TITLE
fix(planner): prompt to clear canvas when address changes with existing objects

### DIFF
--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -709,6 +709,17 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     setSearchQuery(formatSearchPrimary(result));
     const lat = Number(result?.lat), lon = Number(result?.lon);
     if (Number.isFinite(lat) && Number.isFinite(lon)) {
+      // If the map is already set and objects exist, confirm before moving —
+      // objects are stored in canvas coords and will appear at the wrong location
+      // after the map center changes.
+      if (mapCenter && objects.length > 0) {
+        const confirmed = window.confirm(
+          `Moving to a new address will leave your ${objects.length} existing object${objects.length === 1 ? '' : 's'} at the wrong location.\n\nClear the canvas and start fresh at the new address?`
+        );
+        if (!confirmed) { setSearchOpen(false); return; }
+        setObjects([]);
+        setSelectedIds([]);
+      }
       setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1); setV1NoMapBanner(false);
       setSearchStatus(`Centered on ${formatSearchPrimary(result)}`);
     } else { setSearchStatus("Selected result has no coordinates."); }

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -776,7 +776,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
       {/* ─── TOP BAR ─── */}
       <div style={{ height: 48, display: "flex", alignItems: "center", padding: "0 16px", borderBottom: `1px solid ${COLORS.panelBorder}`, background: COLORS.panel, flexShrink: 0, gap: 12 }}>
-        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "hidden" }}>
+        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "visible" }}>
           <a href="/" data-testid="home-link" style={{ display: "flex", alignItems: "center", gap: 8, textDecoration: "none" }} title="Back to home">
             <span style={{ fontSize: 20, color: COLORS.accent }}>◆</span>
             <span style={{ fontSize: 13, fontWeight: 700, color: COLORS.accent, letterSpacing: 1 }}>TCP</span>
@@ -786,7 +786,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
             data-testid="plan-title"
             value={planTitle}
             onChange={(e) => setPlanTitle(e.target.value)}
-            style={{ background: "transparent", border: "none", color: COLORS.text, fontSize: 13, fontWeight: 500, width: 220, padding: "4px 8px", borderRadius: 4, fontFamily: "inherit" }}
+            style={{ background: "transparent", border: "none", color: COLORS.text, fontSize: 13, fontWeight: 500, minWidth: 60, flex: "0 1 180px", padding: "4px 8px", borderRadius: 4, fontFamily: "inherit" }}
           />
           <div style={{ width: 1, height: 24, background: COLORS.panelBorder }} />
           <button onClick={newPlan} style={panelBtnStyle(false)} title="New plan">New</button>

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -706,7 +706,6 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   };
 
   const selectAddressResult = (result: GeocodeResult) => {
-    setSearchQuery(formatSearchPrimary(result));
     const lat = Number(result?.lat), lon = Number(result?.lon);
     if (Number.isFinite(lat) && Number.isFinite(lon)) {
       // If the map is already set and objects exist, confirm before moving —
@@ -717,9 +716,11 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
           `Moving to a new address will leave your ${objects.length} existing object${objects.length === 1 ? '' : 's'} at the wrong location.\n\nClear the canvas and start fresh at the new address?`
         );
         if (!confirmed) { setSearchOpen(false); return; }
-        setObjects([]);
+        // Use resetHistory so undo cannot restore objects at the now-wrong location
+        resetHistory([]);
         setSelectedIds([]);
       }
+      setSearchQuery(formatSearchPrimary(result));
       setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1); setV1NoMapBanner(false);
       setSearchStatus(`Centered on ${formatSearchPrimary(result)}`);
     } else { setSearchStatus("Selected result has no coordinates."); }
@@ -776,7 +777,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
       {/* ─── TOP BAR ─── */}
       <div style={{ height: 48, display: "flex", alignItems: "center", padding: "0 16px", borderBottom: `1px solid ${COLORS.panelBorder}`, background: COLORS.panel, flexShrink: 0, gap: 12 }}>
-        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "visible" }}>
+        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "hidden" }}>
           <a href="/" data-testid="home-link" style={{ display: "flex", alignItems: "center", gap: 8, textDecoration: "none" }} title="Back to home">
             <span style={{ fontSize: 20, color: COLORS.accent }}>◆</span>
             <span style={{ fontSize: 13, fontWeight: 700, color: COLORS.accent, letterSpacing: 1 }}>TCP</span>


### PR DESCRIPTION
## Bug
Changing the job site address while canvas objects existed left all signs, tapers, and roads at their old canvas pixel coordinates — which now correspond to completely wrong geographic positions on the new map.

**Root cause:** `selectAddressResult` updated `mapCenter`, `offset`, and `zoom` but left `objects` untouched. Canvas objects are stored in world-space pixel coordinates; when the map center moves, those pixels now point to a different location on earth.

## Fix
When `mapCenter` is already set and `objects.length > 0`, show a confirmation dialog before moving:

> "Moving to a new address will leave your N existing objects at the wrong location. Clear the canvas and start fresh at the new address?"

- **Confirm** → clears objects + selected IDs, then moves the map
- **Cancel** → leaves everything untouched, closes the search dropdown

First-time address entry (no existing `mapCenter`) is unaffected.

## Reproduction
1. Enter an address and place some signs/tapers
2. Search for a different address
3. Before fix: signs appear at wrong location on new map
4. After fix: confirmation dialog appears; confirming clears canvas cleanly

Fixes reported bug: objects from previous address displayed at new address location.

## Summary by Sourcery

Bug Fixes:
- Add a confirmation dialog when changing to a new address while existing canvas objects are present, optionally clearing them before recentering the map.