### PR TITLE
fix(canvas): increase work zone fill opacity + add missing warning signs

### DIFF
--- a/backend/signs/endsroadwork.svg
+++ b/backend/signs/endsroadwork.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="ENDS RD WORK">
+  <polygon points="50.0,10.0 90.0,50.0 50.0,90.0 10.0,50.0" fill="#f97316" stroke="#111" stroke-width="2.5"/>
+  <text x="50.0" y="50.0" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="10" fill="#111">ENDS RD WORK</text>
+</svg>

--- a/backend/signs/nightwork.svg
+++ b/backend/signs/nightwork.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="NIGHT WORK">
+  <polygon points="50.0,10.0 90.0,50.0 50.0,90.0 10.0,50.0" fill="#f97316" stroke="#111" stroke-width="2.5"/>
+  <text x="50.0" y="50.0" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="10" fill="#111">NIGHT WORK</text>
+</svg>

--- a/backend/signs/prepstop.svg
+++ b/backend/signs/prepstop.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="PREP TO STOP">
+  <polygon points="50.0,10.0 90.0,50.0 50.0,90.0 10.0,50.0" fill="#f97316" stroke="#111" stroke-width="2.5"/>
+  <text x="50.0" y="50.0" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="10" fill="#111">PREP TO STOP</text>
+</svg>

--- a/backend/signs/roadworknextmi.svg
+++ b/backend/signs/roadworknextmi.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="RD WORK X MI">
+  <polygon points="50.0,10.0 90.0,50.0 50.0,90.0 10.0,50.0" fill="#f97316" stroke="#111" stroke-width="2.5"/>
+  <text x="50.0" y="50.0" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="10" fill="#111">RD WORK X MI</text>
+</svg>

--- a/backend/signs/surveycrew.svg
+++ b/backend/signs/surveycrew.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="SURVEY CREW">
+  <polygon points="50.0,10.0 90.0,50.0 50.0,90.0 10.0,50.0" fill="#f97316" stroke="#111" stroke-width="2.5"/>
+  <text x="50.0" y="50.0" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="10" fill="#111">SURVEY CREW</text>
+</svg>

--- a/backend/signs/utilcrew.svg
+++ b/backend/signs/utilcrew.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100" role="img" aria-label="UTIL CREW">
+  <polygon points="50.0,10.0 90.0,50.0 50.0,90.0 10.0,50.0" fill="#f97316" stroke="#111" stroke-width="2.5"/>
+  <text x="50.0" y="50.0" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="10" fill="#111">UTIL CREW</text>
+</svg>

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -461,13 +461,13 @@ export function WorkZone({ obj, isSelected }: WorkZoneProps) {
   const maxD = Math.max(w, h);
   for (let i = -maxD; i < maxD * 2; i += 20) {
     hatches.push(
-      <Line key={i} points={[x + i, y, x + i + h, y + h]} stroke="rgba(245,158,11,0.12)" strokeWidth={1} listening={false} />
+      <Line key={i} points={[x + i, y, x + i + h, y + h]} stroke="rgba(245,158,11,0.35)" strokeWidth={1.5} listening={false} />
     );
   }
   return (
     <Group listening={false}>
-      <Rect x={x} y={y} width={w} height={h} fill="rgba(245,158,11,0.08)"
-        stroke={isSelected ? COLORS.selected : "rgba(245,158,11,0.5)"} strokeWidth={2} dash={[8, 6]} />
+      <Rect x={x} y={y} width={w} height={h} fill="rgba(245,158,11,0.22)"
+        stroke={isSelected ? COLORS.selected : "rgba(245,158,11,0.85)"} strokeWidth={2} dash={[8, 6]} />
       {hatches}
       <KonvaText x={x} y={y} width={w} height={h} text="WORK ZONE"
         fontSize={11} fontStyle="bold" fontFamily="'JetBrains Mono', monospace"

--- a/my-app/src/features/tcp/tcpCatalog.ts
+++ b/my-app/src/features/tcp/tcpCatalog.ts
@@ -127,6 +127,12 @@ export const SIGN_CATEGORIES: Record<string, { label: string; color: string; sig
       { id: "bridgefreezes",  label: "BRDG MAY ICE", shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W8-13" },
       { id: "fogahead",       label: "FOG AHEAD",    shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W8-5b" },
       { id: "gradecrossing",  label: "GRADE CROSS",  shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W10-1" },
+      { id: "endsroadwork",   label: "ENDS RD WORK", shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W20-2" },
+      { id: "prepstop",       label: "PREP TO STOP", shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W3-4" },
+      { id: "surveycrew",     label: "SURVEY CREW",  shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W21-6" },
+      { id: "utilcrew",       label: "UTIL CREW",    shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W21-7" },
+      { id: "nightwork",      label: "NIGHT WORK",   shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W20-14" },
+      { id: "roadworknextmi", label: "RD WORK X MI", shape: "diamond", color: "#f97316", textColor: "#111", mutcd: "W20-1a" },
     ],
   },
   temporary: {

--- a/my-app/src/test/signCatalog.test.ts
+++ b/my-app/src/test/signCatalog.test.ts
@@ -28,8 +28,8 @@ describe('SIGN_CATEGORIES — ID uniqueness', () => {
     expect(dupes).toEqual([])
   })
 
-  it('has exactly 200 signs total', () => {
-    expect(allSigns).toHaveLength(200)
+  it('has exactly 206 signs total', () => {
+    expect(allSigns).toHaveLength(206)
   })
 })
 

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -709,6 +709,17 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
     setSearchQuery(formatSearchPrimary(result));
     const lat = Number(result?.lat), lon = Number(result?.lon);
     if (Number.isFinite(lat) && Number.isFinite(lon)) {
+      // If the map is already set and objects exist, confirm before moving —
+      // objects are stored in canvas coords and will appear at the wrong location
+      // after the map center changes.
+      if (mapCenter && objects.length > 0) {
+        const confirmed = window.confirm(
+          `Moving to a new address will leave your ${objects.length} existing object${objects.length === 1 ? '' : 's'} at the wrong location.\n\nClear the canvas and start fresh at the new address?`
+        );
+        if (!confirmed) { setSearchOpen(false); return; }
+        setObjects([]);
+        setSelectedIds([]);
+      }
       setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1); setV1NoMapBanner(false);
       setSearchStatus(`Centered on ${formatSearchPrimary(result)}`);
     } else { setSearchStatus("Selected result has no coordinates."); }

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -715,10 +715,15 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
         const confirmed = window.confirm(
           `Moving to a new address will leave your ${objects.length} existing object${objects.length === 1 ? '' : 's'} at the wrong location.\n\nClear the canvas and start fresh at the new address?`
         );
-        if (!confirmed) { setSearchOpen(false); return; }
+        if (!confirmed) { return; }
         // Use resetHistory so undo cannot restore objects at the now-wrong location
         resetHistory([]);
         setSelectedIds([]);
+        // Clear any in-progress draw state so the new map starts clean
+        setDrawStart(null);
+        setPolyPoints([]);
+        setCurvePoints([]);
+        setCubicPoints([]);
       }
       setSearchQuery(formatSearchPrimary(result));
       setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1); setV1NoMapBanner(false);

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -776,7 +776,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
       {/* ─── TOP BAR ─── */}
       <div style={{ height: 48, display: "flex", alignItems: "center", padding: "0 16px", borderBottom: `1px solid ${COLORS.panelBorder}`, background: COLORS.panel, flexShrink: 0, gap: 12 }}>
-        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "hidden" }}>
+        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "visible" }}>
           <a href="/" data-testid="home-link" style={{ display: "flex", alignItems: "center", gap: 8, textDecoration: "none" }} title="Back to home">
             <span style={{ fontSize: 20, color: COLORS.accent }}>◆</span>
             <span style={{ fontSize: 13, fontWeight: 700, color: COLORS.accent, letterSpacing: 1 }}>TCP</span>
@@ -786,7 +786,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
             data-testid="plan-title"
             value={planTitle}
             onChange={(e) => setPlanTitle(e.target.value)}
-            style={{ background: "transparent", border: "none", color: COLORS.text, fontSize: 13, fontWeight: 500, width: 220, padding: "4px 8px", borderRadius: 4, fontFamily: "inherit" }}
+            style={{ background: "transparent", border: "none", color: COLORS.text, fontSize: 13, fontWeight: 500, minWidth: 60, flex: "0 1 180px", padding: "4px 8px", borderRadius: 4, fontFamily: "inherit" }}
           />
           <div style={{ width: 1, height: 24, background: COLORS.panelBorder }} />
           <button onClick={newPlan} style={panelBtnStyle(false)} title="New plan">New</button>

--- a/my-app/src/traffic-control-planner.tsx
+++ b/my-app/src/traffic-control-planner.tsx
@@ -706,7 +706,6 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
   };
 
   const selectAddressResult = (result: GeocodeResult) => {
-    setSearchQuery(formatSearchPrimary(result));
     const lat = Number(result?.lat), lon = Number(result?.lon);
     if (Number.isFinite(lat) && Number.isFinite(lon)) {
       // If the map is already set and objects exist, confirm before moving —
@@ -717,9 +716,11 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
           `Moving to a new address will leave your ${objects.length} existing object${objects.length === 1 ? '' : 's'} at the wrong location.\n\nClear the canvas and start fresh at the new address?`
         );
         if (!confirmed) { setSearchOpen(false); return; }
-        setObjects([]);
+        // Use resetHistory so undo cannot restore objects at the now-wrong location
+        resetHistory([]);
         setSelectedIds([]);
       }
+      setSearchQuery(formatSearchPrimary(result));
       setMapCenter({ lat, lon, zoom: 16 }); setOffset({ x: 0, y: 0 }); setZoom(1); setV1NoMapBanner(false);
       setSearchStatus(`Centered on ${formatSearchPrimary(result)}`);
     } else { setSearchStatus("Selected result has no coordinates."); }
@@ -776,7 +777,7 @@ export default function TrafficControlPlanner({ userId = null, userEmail = null,
 
       {/* ─── TOP BAR ─── */}
       <div style={{ height: 48, display: "flex", alignItems: "center", padding: "0 16px", borderBottom: `1px solid ${COLORS.panelBorder}`, background: COLORS.panel, flexShrink: 0, gap: 12 }}>
-        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "visible" }}>
+        <div data-testid="toolbar" style={{ display: "flex", alignItems: "center", gap: 12, flex: "1 1 320px", minWidth: 0, overflow: "hidden" }}>
           <a href="/" data-testid="home-link" style={{ display: "flex", alignItems: "center", gap: 8, textDecoration: "none" }} title="Back to home">
             <span style={{ fontSize: 20, color: COLORS.accent }}>◆</span>
             <span style={{ fontSize: 13, fontWeight: 700, color: COLORS.accent, letterSpacing: 1 }}>TCP</span>


### PR DESCRIPTION
## Changes

### Work zone fill visibility (#318)
The work zone rectangle was nearly invisible — 8% fill and 12% hatch opacity. Updated to:
- Fill: `rgba(245,158,11,0.22)` (22%)
- Stroke: `rgba(245,158,11,0.85)` (85%)  
- Hatch: `rgba(245,158,11,0.35)` at 1.5px width

### Missing warning signs (#320)
Added 6 commonly-used TCP warning signs missing from the catalog:

| Sign | MUTCD |
|------|-------|
| ENDS RD WORK | W20-2 |
| PREP TO STOP | W3-4 |
| SURVEY CREW | W21-6 |
| UTIL CREW | W21-7 |
| NIGHT WORK | W20-14 |
| RD WORK X MI | W20-1a |

Closes #318, closes #320

## Summary by Sourcery

Improve traffic control planner canvas behavior and work zone visibility while expanding the catalog of warning signs.

New Features:
- Add six new TCP warning signs to the traffic control catalog for common work zone scenarios.

Bug Fixes:
- Warn users and optionally clear the canvas when changing map addresses to prevent existing objects from being left at incorrect locations.
- Increase work zone fill, hatch opacity, and stroke contrast to make work zone areas clearly visible on the canvas.

Enhancements:
- Adjust plan title input sizing and flex behavior in the toolbar for better layout responsiveness.