### PR TITLE
fix(canvas): reduce sign size to match TCP schematic scale (#319)

### DIFF
--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -368,7 +368,7 @@ export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
 interface SignShapeProps { obj: SignObject; isSelected: boolean; }
 export function SignShape({ obj, isSelected }: SignShapeProps) {
   const { x, y, signData, rotation = 0, scale: sc = 1 } = obj;
-  const s = 18 * sc;
+  const s = 12 * sc;
   return (
     <Shape
       x={x} y={y}
@@ -420,8 +420,8 @@ export function SignShape({ obj, isSelected }: SignShapeProps) {
         }
         ctx.fillStyle = signData.textColor || "#fff";
         const label = signData.label.length > 12 ? signData.label.slice(0, 11) + "…" : signData.label;
-        const baseFontSize = label.length <= 4 ? 13 : label.length <= 8 ? 11 : 8;
-        ctx.font = `bold ${Math.max(6, baseFontSize * sc)}px 'JetBrains Mono', monospace`;
+        const baseFontSize = label.length <= 4 ? 8 : label.length <= 8 ? 6.5 : 5;
+        ctx.font = `bold ${Math.max(4, baseFontSize * sc)}px 'JetBrains Mono', monospace`;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.fillText(label, 0, shp === "triangle" ? 4 : 0);

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -424,7 +424,7 @@ export function SignShape({ obj, isSelected }: SignShapeProps) {
         ctx.font = `bold ${Math.max(4, baseFontSize * sc)}px 'JetBrains Mono', monospace`;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
-        ctx.fillText(label, 0, shp === "triangle" ? 4 : 0);
+        ctx.fillText(label, 0, shp === "triangle" ? s * 0.3 : 0);
       }}
     />
   );

--- a/my-app/src/shapes/drawSign.ts
+++ b/my-app/src/shapes/drawSign.ts
@@ -7,7 +7,7 @@ export function drawSign(
   isSelected: boolean,
 ): void {
   const { x, y, signData, rotation = 0, scale = 1 } = sign;
-  const s = 18 * scale;
+  const s = 12 * scale;
   ctx.save();
   ctx.translate(x, y);
   ctx.rotate((rotation * Math.PI) / 180);
@@ -58,10 +58,10 @@ export function drawSign(
 
   ctx.fillStyle = signData.textColor || "#fff";
   const label = signData.label.length > 12 ? signData.label.slice(0, 11) + "…" : signData.label;
-  const baseFontSize = label.length <= 4 ? 13 : label.length <= 8 ? 11 : 8;
-  ctx.font = `bold ${Math.max(6, baseFontSize * scale)}px 'JetBrains Mono', monospace`;
+  const baseFontSize = label.length <= 4 ? 8 : label.length <= 8 ? 6.5 : 5;
+  ctx.font = `bold ${Math.max(4, baseFontSize * scale)}px 'JetBrains Mono', monospace`;
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  ctx.fillText(label, 0, shape === "triangle" ? 4 : 0);
+  ctx.fillText(label, 0, shape === "triangle" ? s * 0.3 : 0);
   ctx.restore();
 }


### PR DESCRIPTION
## Summary
- Sign base radius reduced from 18px → 12px (diameter: 36px → 24px)
- At default road width (40px for 2-lane), signs were 90% of road width — now ~60%, matching typical TCP schematic proportions
- Font sizes scaled proportionally (short labels 13→8px, medium 11→6.5px, long 8→5px)

## Test plan
- [ ] Place signs on a 2-lane road and verify they look proportional
- [ ] Zoom in/out to confirm signs scale correctly with roads
- [ ] Check all sign shapes: diamond, octagon, circle, triangle, shield, rect

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust traffic sign rendering on the TCP canvas to better match schematic scale and proportions.

Enhancements:
- Reduce base sign size to be smaller relative to road width for more realistic proportions.
- Scale sign label font sizes down proportionally to maintain readability at the new sign size.