### PR TITLE
feat(devices): arrow board display modes — Left, Right, Caution, Flashing (#324)

### DIFF
--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -368,7 +368,7 @@ export function CubicBezierRoad({ obj, isSelected }: CubicBezierRoadProps) {
 interface SignShapeProps { obj: SignObject; isSelected: boolean; }
 export function SignShape({ obj, isSelected }: SignShapeProps) {
   const { x, y, signData, rotation = 0, scale: sc = 1 } = obj;
-  const s = 18 * sc;
+  const s = 12 * sc;
   return (
     <Shape
       x={x} y={y}
@@ -420,8 +420,8 @@ export function SignShape({ obj, isSelected }: SignShapeProps) {
         }
         ctx.fillStyle = signData.textColor || "#fff";
         const label = signData.label.length > 12 ? signData.label.slice(0, 11) + "…" : signData.label;
-        const baseFontSize = label.length <= 4 ? 13 : label.length <= 8 ? 11 : 8;
-        ctx.font = `bold ${Math.max(6, baseFontSize * sc)}px 'JetBrains Mono', monospace`;
+        const baseFontSize = label.length <= 4 ? 8 : label.length <= 8 ? 6.5 : 5;
+        ctx.font = `bold ${Math.max(4, baseFontSize * sc)}px 'JetBrains Mono', monospace`;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.fillText(label, 0, shp === "triangle" ? 4 : 0);

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -424,7 +424,7 @@ export function SignShape({ obj, isSelected }: SignShapeProps) {
         ctx.font = `bold ${Math.max(4, baseFontSize * sc)}px 'JetBrains Mono', monospace`;
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
-        ctx.fillText(label, 0, shp === "triangle" ? 4 : 0);
+        ctx.fillText(label, 0, shp === "triangle" ? s * 0.3 : 0);
       }}
     />
   );

--- a/my-app/src/components/tcp/canvas/ObjectShapes.tsx
+++ b/my-app/src/components/tcp/canvas/ObjectShapes.tsx
@@ -4,6 +4,7 @@ import type React from 'react';
 import type {
   CanvasObject, StraightRoadObject, PolylineRoadObject, CurveRoadObject, CubicBezierRoadObject,
   SignObject, DeviceObject, ZoneObject, ArrowObject, TextObject, MeasureObject, TaperObject, Point,
+  ArrowBoardMode,
 } from '../../../types';
 import { angleBetween, dist, sampleBezier, sampleCubicBezier, buildOffsetSpine } from '../../../utils';
 import { COLORS, GRID_SIZE, TAPER_SCALE } from '../../../features/tcp/constants';
@@ -430,9 +431,57 @@ export function SignShape({ obj, isSelected }: SignShapeProps) {
   );
 }
 
+/** Draw the amber LED matrix for a specific arrow board mode. */
+function drawArrowBoard(ctx: KonvaContext, mode: ArrowBoardMode) {
+  const W = 28, H = 18; // board dims in canvas px
+  // Board background
+  ctx.fillStyle = '#1a1a1a';
+  ctx.strokeStyle = '#555';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.rect(-W / 2, -H / 2, W, H);
+  ctx.fill(); ctx.stroke();
+
+  ctx.fillStyle = '#fbbf24'; // amber LED colour
+
+  if (mode === 'right') {
+    // Right-pointing chevron arrow →
+    ctx.beginPath();
+    ctx.moveTo(-10, -6); ctx.lineTo(2, -6); ctx.lineTo(2, -10);
+    ctx.lineTo(10, 0);
+    ctx.lineTo(2, 10); ctx.lineTo(2, 6); ctx.lineTo(-10, 6);
+    ctx.closePath(); ctx.fill();
+  } else if (mode === 'left') {
+    // Left-pointing chevron arrow ←
+    ctx.beginPath();
+    ctx.moveTo(10, -6); ctx.lineTo(-2, -6); ctx.lineTo(-2, -10);
+    ctx.lineTo(-10, 0);
+    ctx.lineTo(-2, 10); ctx.lineTo(-2, 6); ctx.lineTo(10, 6);
+    ctx.closePath(); ctx.fill();
+  } else if (mode === 'caution') {
+    // Diamond ◇ pattern
+    ctx.beginPath();
+    ctx.moveTo(0, -7); ctx.lineTo(9, 0); ctx.lineTo(0, 7); ctx.lineTo(-9, 0);
+    ctx.closePath(); ctx.fill();
+  } else {
+    // Flashing — fill whole board with reduced opacity to suggest flash
+    ctx.globalAlpha = 0.6;
+    ctx.fillRect(-W / 2 + 2, -H / 2 + 2, W - 4, H - 4);
+    ctx.globalAlpha = 1;
+  }
+
+  // Mode label below board
+  ctx.fillStyle = COLORS.textMuted;
+  ctx.font = "7px 'JetBrains Mono', monospace";
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillText(mode.toUpperCase(), 0, H / 2 + 2);
+}
+
 interface DeviceShapeProps { obj: DeviceObject; isSelected: boolean; }
 export function DeviceShape({ obj, isSelected }: DeviceShapeProps) {
-  const { x, y, deviceData, rotation = 0 } = obj;
+  const { x, y, deviceData, rotation = 0, arrowBoardMode = 'right' } = obj;
+  const isArrowBoard = deviceData.id === 'arrow_board';
   return (
     <Shape
       x={x} y={y}
@@ -441,14 +490,18 @@ export function DeviceShape({ obj, isSelected }: DeviceShapeProps) {
       shadowBlur={isSelected ? 12 : 0}
       listening={false}
       sceneFunc={(ctx: KonvaContext) => {
-        ctx.fillStyle = deviceData.color;
-        ctx.font = "22px sans-serif";
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillText(deviceData.icon, 0, 0);
-        ctx.fillStyle = COLORS.textMuted;
-        ctx.font = "9px 'JetBrains Mono', monospace";
-        ctx.fillText(deviceData.label, 0, 18);
+        if (isArrowBoard) {
+          drawArrowBoard(ctx, arrowBoardMode);
+        } else {
+          ctx.fillStyle = deviceData.color;
+          ctx.font = "22px sans-serif";
+          ctx.textAlign = "center";
+          ctx.textBaseline = "middle";
+          ctx.fillText(deviceData.icon, 0, 0);
+          ctx.fillStyle = COLORS.textMuted;
+          ctx.font = "9px 'JetBrains Mono', monospace";
+          ctx.fillText(deviceData.label, 0, 18);
+        }
       }}
     />
   );

--- a/my-app/src/components/tcp/panels/PropertyPanel.tsx
+++ b/my-app/src/components/tcp/panels/PropertyPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type {
-  CanvasObject, TaperObject, TurnLaneObject, LaneMaskObject, CrosswalkObject, PlanMeta,
+  CanvasObject, TaperObject, TurnLaneObject, LaneMaskObject, CrosswalkObject, PlanMeta, ArrowBoardMode,
 } from '../../../types';
 import { isPointObject, isLineObject, isMultiPointRoad, calcTaperLength } from '../../../utils';
 import { COLORS } from '../../../features/tcp/constants';
@@ -70,12 +70,36 @@ export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder
       )}
 
       {obj.type === "device" && (
-        <label style={{ fontSize: 11, color: COLORS.textMuted }}>
-          Rotation: {obj.rotation || 0}°
-          <input type="range" min="0" max="360" value={obj.rotation || 0}
-            onChange={(e) => onUpdate(obj.id, { rotation: +e.target.value })}
-            style={{ width: "100%", accentColor: COLORS.accent }} />
-        </label>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <label style={{ fontSize: 11, color: COLORS.textMuted }}>
+            Rotation: {obj.rotation || 0}°
+            <input type="range" min="0" max="360" value={obj.rotation || 0}
+              onChange={(e) => onUpdate(obj.id, { rotation: +e.target.value })}
+              style={{ width: "100%", accentColor: COLORS.accent }} />
+          </label>
+          {obj.deviceData.id === 'arrow_board' && (
+            <div>
+              <div style={{ fontSize: 11, color: COLORS.textMuted, marginBottom: 4 }}>Arrow Board Mode</div>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4 }}>
+                {(['right', 'left', 'caution', 'flashing'] as ArrowBoardMode[]).map((mode) => (
+                  <button
+                    key={mode}
+                    onClick={() => onUpdate(obj.id, { arrowBoardMode: mode })}
+                    style={{
+                      padding: "5px 4px", fontSize: 10, borderRadius: 4, cursor: "pointer",
+                      background: (obj.arrowBoardMode ?? 'right') === mode ? COLORS.accentDim : 'transparent',
+                      color: (obj.arrowBoardMode ?? 'right') === mode ? COLORS.accent : COLORS.textMuted,
+                      border: (obj.arrowBoardMode ?? 'right') === mode ? `1px solid rgba(245,158,11,0.35)` : `1px solid ${COLORS.panelBorder}`,
+                      textTransform: 'uppercase', letterSpacing: 0.5,
+                    }}
+                  >
+                    {mode === 'right' ? '→ Right' : mode === 'left' ? '← Left' : mode === 'caution' ? '◇ Caution' : '✦ Flash'}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       )}
 
       {obj.type === "taper" && (() => {

--- a/my-app/src/components/tcp/panels/PropertyPanel.tsx
+++ b/my-app/src/components/tcp/panels/PropertyPanel.tsx
@@ -84,6 +84,7 @@ export function PropertyPanel({ selected, objects, onUpdate, onDelete, onReorder
                 {(['right', 'left', 'caution', 'flashing'] as ArrowBoardMode[]).map((mode) => (
                   <button
                     key={mode}
+                    aria-pressed={(obj.arrowBoardMode ?? 'right') === mode}
                     onClick={() => onUpdate(obj.id, { arrowBoardMode: mode })}
                     style={{
                       padding: "5px 4px", fontSize: 10, borderRadius: 4, cursor: "pointer",

--- a/my-app/src/shapes/drawSign.ts
+++ b/my-app/src/shapes/drawSign.ts
@@ -7,7 +7,7 @@ export function drawSign(
   isSelected: boolean,
 ): void {
   const { x, y, signData, rotation = 0, scale = 1 } = sign;
-  const s = 18 * scale;
+  const s = 12 * scale;
   ctx.save();
   ctx.translate(x, y);
   ctx.rotate((rotation * Math.PI) / 180);
@@ -58,10 +58,10 @@ export function drawSign(
 
   ctx.fillStyle = signData.textColor || "#fff";
   const label = signData.label.length > 12 ? signData.label.slice(0, 11) + "…" : signData.label;
-  const baseFontSize = label.length <= 4 ? 13 : label.length <= 8 ? 11 : 8;
-  ctx.font = `bold ${Math.max(6, baseFontSize * scale)}px 'JetBrains Mono', monospace`;
+  const baseFontSize = label.length <= 4 ? 8 : label.length <= 8 ? 6.5 : 5;
+  ctx.font = `bold ${Math.max(4, baseFontSize * scale)}px 'JetBrains Mono', monospace`;
   ctx.textAlign = "center";
   ctx.textBaseline = "middle";
-  ctx.fillText(label, 0, shape === "triangle" ? 4 : 0);
+  ctx.fillText(label, 0, shape === "triangle" ? s * 0.3 : 0);
   ctx.restore();
 }

--- a/my-app/src/types.ts
+++ b/my-app/src/types.ts
@@ -108,6 +108,8 @@ export interface SignObject {
   scale: number;
 }
 
+export type ArrowBoardMode = 'right' | 'left' | 'caution' | 'flashing';
+
 export interface DeviceObject {
   id: string;
   type: 'device';
@@ -115,6 +117,8 @@ export interface DeviceObject {
   y: number;
   deviceData: DeviceData;
   rotation: number;
+  /** Only applicable when deviceData.id === 'arrow_board' */
+  arrowBoardMode?: ArrowBoardMode;
 }
 
 export interface ZoneObject {


### PR DESCRIPTION
## Summary
- Adds `ArrowBoardMode` type (`'right' | 'left' | 'caution' | 'flashing'`) to `DeviceObject`
- Arrow boards now render as a dark LED matrix with an amber mode indicator instead of an emoji
- Mode picker (2×2 button grid) appears in Properties panel when an arrow board is selected
- All other devices continue to render with their existing icon + label

## Visuals
| Mode | Appearance |
|------|------------|
| Right (default) | → amber right-pointing chevron on dark board |
| Left | ← amber left-pointing chevron on dark board |
| Caution | ◇ amber diamond on dark board |
| Flashing | amber fill at 60% opacity |

## Test plan
- [ ] Place an arrow board device and verify it renders as a dark rectangle with right arrow (default)
- [ ] Select it and cycle through all 4 modes in the Properties panel
- [ ] Verify mode persists in the layers panel and after undo/redo
- [ ] Verify non-arrow-board devices (cones, drums, etc.) are unaffected

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable display modes for arrow board devices and update their canvas rendering and properties panel UI.

New Features:
- Introduce an ArrowBoardMode type on DeviceObject to track arrow board display state.
- Add an Arrow Board Mode selector in the properties panel for arrow board devices.

Enhancements:
- Render arrow board devices as a dark LED matrix with mode-specific indicators instead of an emoji icon.
- Adjust sign shape sizing and font scaling to improve label legibility on the canvas.